### PR TITLE
Retirar o texto "DANFE" das notas canceladas

### DIFF
--- a/libs/DanfeNFePHP.class.php
+++ b/libs/DanfeNFePHP.class.php
@@ -851,13 +851,17 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP {
         $w2 = $w;
         $h = 32;
         $this->__textBox($x,$y,$w,$h);
-        $texto = "DANFE";
-        $aFont = array('font'=>$this->fontePadrao,'size'=>14,'style'=>'B');
-        $this->__textBox($x,$y+1,$w,$h,$texto,$aFont,'T','C',0,'');
-        $aFont = array('font'=>$this->fontePadrao,'size'=>8,'style'=>'');
-        $texto = 'Documento Auxiliar da Nota Fiscal Eletrônica';
-        $h = 20;
-        $this->__textBox($x,$y+6,$w,$h,$texto,$aFont,'T','C',0,'',FALSE);
+
+        if( ! $this->__notaCancelada() ) {
+            $texto = "DANFE";
+            $aFont = array('font'=>$this->fontePadrao,'size'=>14,'style'=>'B');
+            $this->__textBox($x,$y+1,$w,$h,$texto,$aFont,'T','C',0,'');
+            $aFont = array('font'=>$this->fontePadrao,'size'=>8,'style'=>'');
+            $texto = 'Documento Auxiliar da Nota Fiscal Eletrônica';
+            $h = 20;
+            $this->__textBox($x,$y+6,$w,$h,$texto,$aFont,'T','C',0,'',FALSE);
+        }
+        
         $aFont = array('font'=>$this->fontePadrao,'size'=>8,'style'=>'');
         $texto = '0 - ENTRADA';
         $y1 = $y + 14;


### PR DESCRIPTION
Segundo a página 97 do Manual da NFe v5.0,

---

Os campos do DANFE deverão representar o conteúdo das respectivas TAG XML da NF-e, 
quando conhecidos no momento da solicitação de autorização de uso. Não poderão ser 
## impressas informações que não constem do arquivo da NF-e. 

Assim sendo, escrever NFe Cancelada, embora algo extremamente prático, ao meu humilde entender, é crime. Note que sou um mero programador e isso é uma simples opinião.

Todavia acredito que se nós tirarmos o texto "DANFE  - Documento Auxiliar da Nota Fiscal Eletrônica", o documento deixa de ser uma DANFE e com isso é possível escrevermos o que quiser no PDF gerado.

Imagino que esta solução deixe nossos clientes e os respectivos contadores satisfeitos ( pois não irão perceber ) e não fere nenhuma lei. Acredito também que o princípio da boa fé objetiva está do nosso lado.
