### PR TITLE
Melhorias no DANFE: Full logo e controle de itens VS páginas melhorado

### DIFF
--- a/libs/DanfeNFePHP.class.php
+++ b/libs/DanfeNFePHP.class.php
@@ -854,7 +854,7 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
             $tw = $w;
         }
         // monta as informações apenas se diferente de full logo
-        if ($this->logoAlign <> 'F') {
+        if ($this->logoAlign !== 'F') {
            //Nome emitente
            $aFont = array('font'=>$this->fontePadrao,'size'=>12,'style'=>'B');
            $texto = $this->emit->getElementsByTagName("xNome")->item(0)->nodeValue;
@@ -2681,4 +2681,3 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
     } // fim __geraInformacoesDasNotasReferenciadas
 
 } //fim da classe DanfeNFePHP
-?>


### PR DESCRIPTION
1) Correções diversas simplificadas apenas de identação; 2) Adicionada verificação dos itens processados em relação à quantidade total de itens, para corrigir casos raros de geração de páginas erradas (por exemplo, última página em branco sem itens, ou faltando o último item na última página); 3) Adicionada opção "F-Full" na exibição do logotipo, neste caso o DANFE não monta os textos, apenas a imagem do logotipo, caso a empresa tenha o endereço no próprio logotipo.
