### PR TITLE
Mudando apoontamento dos exemplos aos XMLs

### DIFF
--- a/exemplos/testaCTeSendLot.php
+++ b/exemplos/testaCTeSendLot.php
@@ -3,8 +3,8 @@ require_once('../libs/CTeNFePHP.class.php');
 $nfe = new CTeNFePHP;
 $modSOAP = '2'; //usando cURL
 
-//use isso, este é o modo manual voce tem mais controle sobre o que acontece  
-$filename = '0008-cte.xml';
+//use isso, este é o modo manual voce tem mais controle sobre o que acontece
+$filename = 'xml/0008-cte.xml';
 //obter um numero de lote
 
 
@@ -24,7 +24,7 @@ $aCTe = array(0=>file_get_contents($filename));
 
 if ($aResp = $nfe->sendLot($aCTe, $lote, $modSOAP)){
     if ($aResp['bStat']){
-        echo "Numero do Recibo : " . $aResp['nRec'] .", use este numero para obter o protocolo ou informações de erro no xml com testaRecibo.php.";  
+        echo "Numero do Recibo : " . $aResp['nRec'] .", use este numero para obter o protocolo ou informações de erro no xml com testaRecibo.php.";
     } else {
         echo "Houve erro !! $nfe->errMsg";
     }
@@ -36,11 +36,11 @@ echo '<PRE>';
 echo htmlspecialchars($nfe->soapDebug);
 echo '</PRE><BR>';
 
-//ou isso 
+//ou isso
 //este é modo interno e vai enviar todoas as nf que estiverem na pasta validadas
 /*
 if ($recibo  = $nfe->autoEnvNFe()){
-    echo "Numero do Recibo : " . $recibo .", use este numero para obter o protocolo ou informações de erro no xml.";  
+    echo "Numero do Recibo : " . $recibo .", use este numero para obter o protocolo ou informações de erro no xml.";
 } else {
     echo "Houve erro !! $nfe->errMsg";
 }

--- a/exemplos/testaDanfeNFCe.php
+++ b/exemplos/testaDanfeNFCe.php
@@ -9,7 +9,7 @@ if (!isset($_REQUEST['o'])) {
     $saida = 'pdf';
 }
 
-$arq = './exemploNFCe.xml';
+$arq = 'xml/exemploNFCe.xml';
 if (is_file($arq)) {
     $docxml = file_get_contents($arq);
     $danfe = new DanfeNFCeNFePHP($docxml, '', 0);

--- a/exemplos/testaNFeAssina.php
+++ b/exemplos/testaNFeAssina.php
@@ -2,7 +2,7 @@
 require_once('../libs/ToolsNFePHP.class.php');
 $nfe = new ToolsNFePHP;
 
-$file = '35130471780456000160550010000000411000000410-nfe.xml';
+$file = 'xml/35130471780456000160550010000000411000000410-nfe.xml';
 $arq = file_get_contents($file);
 
 if ($xml = $nfe->signXML($arq, 'infNFe')){

--- a/exemplos/testaNFeCancelEvent.php
+++ b/exemplos/testaNFeCancelEvent.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * testaCancelaEvent
- * 
+ *
  * Rotina de teste de cancelamento por evento
- * 
+ *
  * Corrija os dados para o cancelamento antes de testar
  */
 require_once('../libs/ToolsNFePHP.class.php');
@@ -25,5 +25,5 @@ if ($resp = $nfe->cancelEvent($chNFe,$nProt,$xJust,$tpAmb,$modSOAP)){
     echo '<PRE>';
     echo htmlspecialchars($nfe->soapDebug);
     echo '</PRE><BR>';
-}    
+}
 ?>

--- a/exemplos/testaNFeConvertTXT.php
+++ b/exemplos/testaNFeConvertTXT.php
@@ -2,20 +2,23 @@
 
 require_once('../libs/ConvertNFePHP.class.php');
 
-$arq = './0008.txt';
+$arq = 'xml/0008.txt';
 
 //instancia a classe
 $nfe = new ConvertNFePHP();
 
+
 if ( is_file($arq) ){
     $xml = $nfe->nfetxt2xml($arq);
+    $xml = $xml[0];
+
     if ($xml != ''){
         echo '<PRE>';
         echo htmlspecialchars($xml);
         echo '</PRE><BR>';
         if (!file_put_contents('0008-nfe.xml',$xml)){
             echo "ERRO na gravação";
-        }    
+        }
     }
 }
 

--- a/exemplos/testaNFeDANFE.php
+++ b/exemplos/testaNFeDANFE.php
@@ -5,7 +5,7 @@
 require_once('../libs/DanfeNFePHP.class.php');
 
 //$arq = $_GET['nfe'];
-$arq = './35101158716523000119550010000000011003000000-nfe.xml';
+$arq = 'xml/35101158716523000119550010000000011003000000-nfe.xml';
 
 if ( is_file($arq) ){
     $docxml = file_get_contents($arq);

--- a/exemplos/testaNFeEnvio.php
+++ b/exemplos/testaNFeEnvio.php
@@ -6,8 +6,8 @@ require_once('../libs/ToolsNFePHP.class.php');
 $nfe = new ToolsNFePHP;
 $modSOAP = '2'; //usando cURL
 
-//use isso, este é o modo manual voce tem mais controle sobre o que acontece  
-$filename = './35101158716523000119550010000000011003000000-nfe.xml';
+//use isso, este é o modo manual voce tem mais controle sobre o que acontece
+$filename = 'xml/35101158716523000119550010000000011003000000-nfe.xml';
 //obter um numero de lote
 $lote = substr(str_replace(',','',number_format(microtime(true)*1000000,0)),0,15);
 // montar o array com a NFe
@@ -15,7 +15,7 @@ $aNFe = array(0=>file_get_contents($filename));
 //enviar o lote
 if ($aResp = $nfe->sendLot($aNFe, $lote, $modSOAP)){
     if ($aResp['bStat']){
-        echo "Numero do Recibo : " . $aResp['nRec'] .", use este numero para obter o protocolo ou informações de erro no xml com testaRecibo.php.";  
+        echo "Numero do Recibo : " . $aResp['nRec'] .", use este numero para obter o protocolo ou informações de erro no xml com testaRecibo.php.";
     } else {
         echo "Houve erro !! $nfe->errMsg";
     }

--- a/exemplos/testaNFePrintCCe.php
+++ b/exemplos/testaNFePrintCCe.php
@@ -1,7 +1,7 @@
 <?php
 require_once('../libs/DacceNFePHP.class.php');
 
-$arq = './10142785000190-cce.xml';
+$arq = 'xml/10142785000190-cce.xml';
 $aEnd = array('razao'=>'HOTEL COPACABANA','logradouro' => 'AV. ATLANTICA','numero' => '1702','complemento' => '','bairro' => 'COPACABANA','CEP' => '22021001','municipio' => 'RIO DE JANEIRO','UF'=>'RJ','telefone'=>'2100000000','email'=>'copa@copapalace.com.br');
 if ( is_file($arq) ){
     $cce = new DacceNFePHP($arq, 'P', 'A4','../images/logo.jpg','I',$aEnd,'','Times',1);

--- a/exemplos/testaNFeRecibo.php
+++ b/exemplos/testaNFeRecibo.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Exemplo de solicitação da situação da NFe atraves do numero do 
+ * Exemplo de solicitação da situação da NFe atraves do numero do
  * recibo de uma nota enviada e recebida com sucesso pelo SEFAZ
  */
 require_once('../libs/ToolsNFePHP.class.php');
@@ -18,5 +18,5 @@ if ($aResp = $nfe->getProtocol($recibo, $chave, $tpAmb, $modSOAP)){
     //não houve retorno mostrar erro de comunicação
     echo "Houve erro !! $nfe->errMsg";
 }
-        
+
 ?>

--- a/exemplos/testaNFeValidaXML.php
+++ b/exemplos/testaNFeValidaXML.php
@@ -1,6 +1,6 @@
 <?php
 require_once('../libs/ToolsNFePHP.class.php');
-$arq = './35120458716523000119550000000170081362715831-nfe.xml';
+$arq = 'xml/11101284613439000180550010000004881093997017-nfe.xml';
 //$arq = './35120358716523000119550000000162421280334154-nfe.xml';
 $nfe = new ToolsNFePHP;
 $docxml = file_get_contents($arq);

--- a/exemplos/testaNFeValidade.php
+++ b/exemplos/testaNFeValidade.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * Este é um exemplo para verificação da validade de uma NFe recebida de terceiros
- * esta NFe deve ter o seu protocolo anexado 
- * O método irá verificar a aasinatura digital, o protocolo e o digest fornecido pela SEFAZ 
+ * esta NFe deve ter o seu protocolo anexado
+ * O método irá verificar a aasinatura digital, o protocolo e o digest fornecido pela SEFAZ
  * através de uma consulta ao SEFAZ do estado do emissor
  */
 header('Content-type: text/html; charset=UTF-8');
 require_once('../libs/ToolsNFePHP.class.php');
 $nfe = new ToolsNFePHP;
 //path para o arquivo da NFe recebida de terceiros que se quer verificar a validade
-$fileNFe = "./31110303013973000749550010000222330108804222-nfe.xml";
+$fileNFe = "xml/35101158716523000119550010000000011003000000-nfe.xml";
 if( !$nfe->verifyNFe($fileNFe) ){
     echo $nfe->errMsg;
 } else {

--- a/exemplos/xml/exemploNFCe.xml
+++ b/exemplos/xml/exemploNFCe.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nfeProc xmlns="http://www.portalfiscal.inf.br/nfe" versao="3.00">
+    <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+        <infNFe Id="NFe13130604501136000136650020000973882010222458" versao="3.00">
+            <ide>
+                <cUF>13</cUF>
+                <cNF>01022245</cNF>
+                <natOp>VENDA DE MERCADORIA</natOp>
+                <indPag>1</indPag>
+                <mod>65</mod>
+                <serie>2</serie>
+                <nNF>97388</nNF>
+                <dhEmi>2013-06-11T08:50:26-04:00</dhEmi>
+                <tpNF>1</tpNF>
+                <idDest>1</idDest>
+                <cMunFG>1302603</cMunFG>
+                <tpImp>4</tpImp>
+                <tpEmis>1</tpEmis>
+                <cDV>8</cDV>
+                <tpAmb>2</tpAmb>
+                <finNFe>1</finNFe>
+                <indFinal>1</indFinal>
+                <indPres>1</indPres>
+                <procEmi>0</procEmi>
+                <verProc>V2.245</verProc>
+            </ide>
+            <emit>
+                <CNPJ>04501136000136</CNPJ>
+                <xNome>L J GUERRA E CIA LTDA</xNome>
+                <enderEmit>
+                    <xLgr>AV GEN RODRIGO OTAVIO</xLgr>
+                    <nro>4050</nro>
+                    <xCpl>01-1</xCpl>
+                    <xBairro>JAPIIM</xBairro>
+                    <cMun>1302603</cMun>
+                    <xMun>MANAUS</xMun>
+                    <UF>AM</UF>
+                    <CEP>69077000</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>Brasil</xPais>
+                    <fone>9221211500</fone>
+                </enderEmit>
+                <IE>041616740</IE>
+                <CRT>3</CRT>
+            </emit>
+            <dest>
+                <CPF>00500113456</CPF>
+                <xNome>GUSTAVO SILVA OLIVEIRA</xNome>
+                <enderDest>
+                    <xLgr>RUA JOÃO PAULO I</xLgr>
+                    <nro>201</nro>
+                    <xCpl>fundos</xCpl>
+                    <xBairro>BETANIA</xBairro>
+                    <cMun>1302603</cMun>
+                    <xMun>MANAUS</xMun>
+                    <UF>AM</UF>
+                    <CEP>69073070</CEP>
+                    <cPais>1058</cPais>
+                    <xPais>BRASIL</xPais>
+                    <fone>9281833171</fone>
+                </enderDest>
+            </dest>
+            <det nItem="1">
+                <prod>
+                    <cProd>84776</cProd>
+                    <cEAN/>
+                    <xProd>SUP LAV BEGE LA 30YY 65 171 5296 P16L</xProd>
+                    <NCM>32091010</NCM>
+                    <CFOP>5405</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>230.0000</vUnCom>
+                    <vProd>230.00</vProd>
+                    <cEANTrib/>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>230.0000</vUnTrib>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS60>
+                            <orig>0</orig>
+                            <CST>60</CST>
+                            <vBCSTRet>0.00</vBCSTRet>
+                            <vICMSSTRet>0.00</vICMSSTRet>
+                        </ICMS60>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>230.00</vBC>
+                            <pPIS>0.65</pPIS>
+                            <vPIS>1.50</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>230.00</vBC>
+                            <pCOFINS>3.00</pCOFINS>
+                            <vCOFINS>6.90</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+            </det>
+            <det nItem="2">
+                <prod>
+                    <cProd>14508</cProd>
+                    <cEAN>7891019152452</cEAN>
+                    <xProd>TINTA ACR DECORA SUPER LAV BRANCO ACET 3,6LT CORAL</xProd>
+                    <NCM>32091010</NCM>
+                    <CFOP>5405</CFOP>
+                    <uCom>UN</uCom>
+                    <qCom>1.0000</qCom>
+                    <vUnCom>55.0000</vUnCom>
+                    <vProd>55.00</vProd>
+                    <cEANTrib>7891019152452</cEANTrib>
+                    <uTrib>UN</uTrib>
+                    <qTrib>1.0000</qTrib>
+                    <vUnTrib>55.0000</vUnTrib>
+                    <vDesc>2.20</vDesc>
+                    <indTot>1</indTot>
+                </prod>
+                <imposto>
+                    <ICMS>
+                        <ICMS60>
+                            <orig>0</orig>
+                            <CST>60</CST>
+                            <vBCSTRet>0.00</vBCSTRet>
+                            <vICMSSTRet>0.00</vICMSSTRet>
+                        </ICMS60>
+                    </ICMS>
+                    <PIS>
+                        <PISAliq>
+                            <CST>01</CST>
+                            <vBC>52.80</vBC>
+                            <pPIS>0.65</pPIS>
+                            <vPIS>0.34</vPIS>
+                        </PISAliq>
+                    </PIS>
+                    <COFINS>
+                        <COFINSAliq>
+                            <CST>01</CST>
+                            <vBC>52.80</vBC>
+                            <pCOFINS>3.00</pCOFINS>
+                            <vCOFINS>1.58</vCOFINS>
+                        </COFINSAliq>
+                    </COFINS>
+                </imposto>
+            </det>
+            <total>
+                <ICMSTot>
+                    <vBC>0.00</vBC>
+                    <vICMS>0.00</vICMS>
+                    <vBCST>0.00</vBCST>
+                    <vST>0.00</vST>
+                    <vProd>285.00</vProd>
+                    <vFrete>0.00</vFrete>
+                    <vSeg>0.00</vSeg>
+                    <vDesc>2.20</vDesc>
+                    <vII>0.00</vII>
+                    <vIPI>0.00</vIPI>
+                    <vPIS>1.84</vPIS>
+                    <vCOFINS>8.48</vCOFINS>
+                    <vOutro>0.00</vOutro>
+                    <vNF>282.80</vNF>
+                </ICMSTot>
+            </total>
+            <transp>
+                <modFrete>9</modFrete>
+            </transp>
+            <pag>
+                <tPag>03</tPag>
+                <vPag>141.40</vPag>
+                <card>
+                    <CNPJ>60889128000422</CNPJ>
+                    <tBand>02</tBand>
+                    <cAut>110011</cAut>
+                </card>
+            </pag>
+            <pag>
+                <tPag>03</tPag>
+                <vPag>141.40</vPag>
+                <card>
+                    <CNPJ>60889128000422</CNPJ>
+                    <tBand>02</tBand>
+                    <cAut>110011</cAut>
+                </card>
+            </pag>
+            <infAdic/>
+        </infNFe>
+        <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <SignedInfo>
+                <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+                <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+                <Reference URI="#NFe13130604501136000136650020000136261010222458">
+                    <Transforms>
+                        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+                    </Transforms>
+                    <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                    <DigestValue>a3XXXoUSXXBBWl234FNRdA1673U=</DigestValue>
+                </Reference>
+            </SignedInfo>
+            <SignatureValue>ZYZo8lq1RLEo/q6TewsRamDweKn0jEXV29rirKm63b7o6qrSNmSreUKpZOGzwPiZz8xNeLjDdS6g
+U1K1FyBup2NhNuqE4X2oE9MahEJEdektHaF/GZDfff9A48GmaNwQo3LQ7Im+KmZLO8kHCX3eZqFz
+vqaaPrZjwHtr6ZUj/LMMMbClxaR0M4VfbEtL74YPUVqfKIZC/gcPp2WFlnGtm1rRI//LK3KDEc2v
+pJXDWj5sNJaE0z9FjzLZp2lXWAJdyAVHijCpSE4uZeMQrwTj4F8hcO1WwRYd96MwmG1VDfNGM8a6
+B/7zD19uU/TE4Ep4Bp9dx3gkOoNtLP5Fyo0fdw==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIHxzCCBa+gAwIBAgIISGin1tcEtYswDQYJKoZIhvcNAQELBQAwTDELMAkGA1UEBhMCQlIxEzAR
+BgNVBAoTCklDUC1CcmFzaWwxKDAmBgNVBAMTH1NFUkFTQSBDZXJ0aWZpY2Fkb3JhIERpZ2l0YWwg
+djIwHhcNMTIxMDI1MTk1MzAwWhcNMTMxMDI1MTk1MzAwWjCB4DELMAkGA1UEBhMCQlIxEzARBgNV
+BAoTCklDUC1CcmFzaWwxFDASBgNVBAsTCyhFTSBCUkFOQ08pMRgwFgYDVQQLEw8wMDAwMDEwMDM2
+NjE3MzUxFDASBgNVBAsTCyhFTSBCUkFOQ08pMRQwEgYDVQQLEwsoRU0gQlJBTkNPKTEUMBIGA1UE
+CxMLKEVNIEJSQU5DTykxFDASBgNVBAsTCyhFTSBCUkFOQ08pMRQwEgYDVQQLEwsoRU0gQlJBTkNP
+KTEeMBwGA1UEAxMVTCBKIEdVRVJSQSBFIENJQSBMVERBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAxVJUqBH+hsxaNkihIR9SwLOJ/MaME288DQD7AUw/Dyincl1EOEx77rWrRoVw3+bL
+0+fzHEAreEioA/MmLb6N9hHchs9OgICchvdQSXU7AdAuHjJpRhC8WNgdu3G8RoQK0C7NkKgvHDT+
+q4RVmae5nmzG+Gq+mfu5cZqHKoMJNjzgMoaUSX0mqv9ST3yT8oVE04Y64CW0vWHG8B+Lt2IUr/B6
+eyTsJps5NhqC6Eo5kJPjcD18ZmM3SmoLWGhfbEU7/NjGCH8rrx6KpxToJvt7gV9m4tZmZo/uShQH
+nhrsittXXqsZMIkA/AVK413GC6nq2w+sCOm19IM9fQ9H509glwIDAQABo4IDFjCCAxIwgZcGCCsG
+AQUFBwEBBIGKMIGHMEcGCCsGAQUFBzAChjtodHRwOi8vd3d3LmNlcnRpZmljYWRvZGlnaXRhbC5j
+b20uYnIvY2FkZWlhcy9zZXJhc2FjZHYyLnA3YjA8BggrBgEFBQcwAYYwaHR0cDovL29jc3AuY2Vy
+dGlmaWNhZG9kaWdpdGFsLmNvbS5ici9zZXJhc2FjZHYyMB8GA1UdIwQYMBaAFJrggxDXJpvputqC
+soHOORrTh3CGMHEGA1UdIARqMGgwZgYGYEwBAgEGMFwwWgYIKwYBBQUHAgEWTmh0dHA6Ly9wdWJs
+aWNhY2FvLmNlcnRpZmljYWRvZGlnaXRhbC5jb20uYnIvcmVwb3NpdG9yaW8vZHBjL2RlY2xhcmFj
+YW8tc2NkLnBkZjCB8AYDVR0fBIHoMIHlMEmgR6BFhkNodHRwOi8vd3d3LmNlcnRpZmljYWRvZGln
+aXRhbC5jb20uYnIvcmVwb3NpdG9yaW8vbGNyL3NlcmFzYWNkdjIuY3JsMEOgQaA/hj1odHRwOi8v
+bGNyLmNlcnRpZmljYWRvcy5jb20uYnIvcmVwb3NpdG9yaW8vbGNyL3NlcmFzYWNkdjIuY3JsMFOg
+UaBPhk1odHRwOi8vcmVwb3NpdG9yaW8uaWNwYnJhc2lsLmdvdi5ici9sY3IvU2VyYXNhL3JlcG9z
+aXRvcmlvL2xjci9zZXJhc2FjZHYyLmNybDAOBgNVHQ8BAf8EBAMCBeAwHQYDVR0lBBYwFAYIKwYB
+BQUHAwIGCCsGAQUFBwMEMIG/BgNVHREEgbcwgbSBF0NQREBDQVNBREFTQ09SUkVJQVMuQ09NoD4G
+BWBMAQMEoDUTMzAyMDExOTYzMDIyMzI2NjQ4NTYwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw
+MDAwMKAlBgVgTAEDAqAcExpKT0RJQkVSVE8gTEVNQVIgREFMTCBPR0xJT6AZBgVgTAEDA6AQEw4w
+NDUwMTEzNjAwMDEzNqAXBgVgTAEDB6AOEwwwMDAwMDAwMDAwMDAwDQYJKoZIhvcNAQELBQADggIB
+ADxraixJl/YJK8pKDIv1iR4UuPBx4KjpDSSJj48T12T0jxFK1woTQQqGzBFBpv6ShqIRmlux/V8P
+xqhF30LMObq4mNjLkn9l2Fk7vbYCFrLU+f5ag+0y5e4YbNUtVlfc2Rva9IodaOp8MOzNIEhBcvaw
+ODL826iTkJkMNWYytygDZaJWLGjXI7JN/XvXCg0thrQ5s2MlGIkMYdV7MxvilN5Qsk5Prt4P59hx
+NZJ3fvAJ9zCE/tUH0QqpOFIVWrpEOelUad6ZOVZFIbRIGXykfRFM6Rj/aqnH/me7Kmyb7jPewQnz
+TtSs1GNQqQHknJRtQn4LsrJV/qo2ZyxTOnqtvuXu8tzbrnXwuTmlaUYkcK7do4w6QjIrKr8qp2Zy
+dJ63seLxiixrEioXwZ/m68Qyx6abxLndPTPDHDjvdi8JvM/ckzaQiF9+uFR63mlc0omkE9PhElLA
+6wGhvTs0co8QRvLYvOUt8HbF1hqnSWmroivq/WwKgvSf2b3kuMBYGhKmC0vqwzGU6s/Ml9LZky4j
+0K1xxRMV0+pG/R3huuS0WRz3uJ2k7d1WK3mymQ1+gBlcNFBqCtCjo5wGLMLmL9P9ETLQwm+5yCxf
+MzVDDMRQpJddtajP16cvGjZQe0CSnHuDELN3AQJRntdRqs1uMKGUcUzu3Oa5nJSLx6HygqU4z6Ve</X509Certificate></X509Data></KeyInfo></Signature></NFe>
+<protNFe versao="3.00">
+    <infProt>
+        <tpAmb>1</tpAmb>
+        <verAplic>XXXX</verAplic>
+        <chNFe>13130604501136000136650020000973882010222458</chNFe>
+        <dhRecbto>2013-06-11T08:52:33-04:00</dhRecbto>
+        <nProt>113130093474232</nProt>
+        <digVal>a3XXXoUSXXBBWl234FNRdA1673U=</digVal>
+        <cStat>100</cStat>
+        <xMotivo>Autorizado o uso da NF-e</xMotivo>
+    </infProt>
+</protNFe>
+</nfeProc>


### PR DESCRIPTION
Alterei os caminhos que apontavam para os XMLs de teste dentro da pasta exemplos. Ele estavam chamando os arquivos apontando para a pasta exemplos, mas na verdade estão dentro de exemplos/xml. Tudo isso para melhorar a experiência de novos usuários.
