### PR TITLE
Correção do composer.json para seguir a convenção de nomes do Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "nfephp",
+    "name": "nfephp-org/nfephp",
     "type": "library",
     "description": "NFePHP é uma API para gerenciamento das comunicações entre o emitente de NFe e os serviços dos SEFAZ estaduais. Inteiramente construído em PHP para rodar sob qualquer sistema operacional.",
-	"keywords": [
+    "keywords": [
         "nfe",
         "nfephp",
         "spedphp",
@@ -55,3 +55,4 @@
         ]
     }
 }
+


### PR DESCRIPTION
Seria interessante a inserção do projeto ao [Packagist](https://packagist.org/) e tentar solicitar aos criadores de forks como [nfephp/nfephp](https://packagist.org/packages/nfephp/nfephp) removerem os pacotes para evitarem confusões.

Editei o composer.json para seguir a convenção de nomenclatura do Composer, para se caso a sugestão for aceita.
