### PR TITLE
[UPD] Alteração do composer.json substituindo as letras acentuadas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         "nfephp",
         "spedphp",
         "sped",
-        "nota fiscal eletrônica",
-        "nota fiscal de serviços"
+        "nota fiscal eletronica",
+        "nota fiscal de servicos"
     ],
     "homepage": "https://github.com/nfephp-org/nfephp",
     "license": [


### PR DESCRIPTION
Conforme eu conversei com o Seldaek no IRC, não há motivos para o Packagist aceitar keywords com acentos. Então para que o pacote seja aceito, removi os acentos das keywords.
