### PR TITLE
ConvertCteNFePHP.class.php [Remetente com CPF]

### DIFF
--- a/libs/ConvertCteNFePHP.class.php
+++ b/libs/ConvertCteNFePHP.class.php
@@ -811,7 +811,9 @@ class ConvertCteNFePHP{ //implements ConvertCTePHP{
 						$cur_grupo	=& $REM;
 						// campo 'email' não existe no TXT
 						foreach($campos as $nome_campo){
-							if(	$nome_campo=='xFant' || $nome_campo=='CEP' || $nome_campo=='xCpl'){
+							if(	$nome_campo=='CNPJ' || $nome_campo=='CPF' || 
+								$nome_campo=='xFant' || $nome_campo=='CEP' || 
+								$nome_campo=='xCpl'){
 								if(empty($v2[$nome_campo]))	
 									continue;
 							}


### PR DESCRIPTION
Mesmo com o campos CNPJ vazio, a classe estava criando o elemento </cnpj> o que impedia o envio do arquivo...
