### PR TITLE
1) Classe DomDocumentNFePHP, removido método

### DIFF
--- a/libs/Common/CommonNFePHP.class.php
+++ b/libs/Common/CommonNFePHP.class.php
@@ -31,6 +31,7 @@
  * @author      Marcos Diez <marcos at unitron dot com dot br>
  *
  *        CONTRIBUIDORES (por ordem alfabetica):
+ *          Fernando Mertins <fernando dot mertins at gmail dot com>
  *          Roberto L. Machado <linux dot rlm at gmail dot com> 
  *
  * Esta classe depende de PdfNFePHP.class.php e deve ser utilizada pelas classes DanfeNFePHP e DacteNFePHP
@@ -87,17 +88,17 @@ class CommonNFePHP
      * pSimpleGetValue
      * Extrai o valor do node DOM
      * @author Marcos Diez
-     * @param DOM $theObj
+     * @param object $theObj Instancia de DOMDocument ou DOMElement
      * @param string $keyName identificador da TAG do xml
      * @param string $extraTextBefore prefixo do retorno
      * @param string extraTextAfter sufixo do retorno
      * @param number itemNum numero do item a ser retornado
      * @return string
      */
-    protected function pSimpleGetValue($theObj, $keyName , $extraTextBefore = '', $extraTextAfter = '', $itemNum = 0)
+    protected function pSimpleGetValue($theObj, $keyName, $extraTextBefore = '', $extraTextAfter = '', $itemNum = 0)
     {
-        if (!isset($theObj) || !is_object($theObj)) {
-            return '';
+        if (!($theObj instanceof DOMDocument) && !($theObj instanceof DOMElement)) {
+            throw new nfephpException("Metodo CommonNFePHP::pSimpleGetValue() com parametro do objeto invalido, verifique!");
         }
         $vct = $theObj->getElementsByTagName($keyName)->item($itemNum);
         if (isset($vct)) {
@@ -107,7 +108,7 @@ class CommonNFePHP
     } //fim pSimpleGetValue
 
     /**
-     * __simpleGetDate
+     * pSimpleGetDate
      * Recupera e reformata a data do padrão da NFe para dd/mm/aaaa
      * @author Marcos Diez
      * @param DOM $theObj
@@ -126,7 +127,7 @@ class CommonNFePHP
             return $extraText . $theDate[2] . "/" . $theDate[1] . "/" . $theDate[0];
         }
         return '';
-    } //fim __simpleGetDate
+    } //fim pSimpleGetDate
 
     /**
      * __modulo11

--- a/libs/Common/DomDocumentNFePHP.class.php
+++ b/libs/Common/DomDocumentNFePHP.class.php
@@ -50,30 +50,4 @@ class DomDocumentNFePHP extends DOMDocument
         $this->formatOutput = false;
         $this->preserveWhiteSpace = false;
     }
-
-    /**
-     * getElementsByTagNameOpcional
-     * Apenas uma simplificação de "getElementsByTagName($nome)->item(0)->nodeValue"
-     * com a verificação se está vazio, para evitar repetições densas de operadores
-     * ternários ao longo do código
-     * @param string $nome
-     * @param mixed $valorSeVazio
-     * @throws nfephpException
-     * @return mixed
-     */
-    public function getElementsByTagNameOpcional($nome, $valorSeVazio = '')
-    {
-        $element = $this->getElementsByTagName($nome)->item(0);
-        //validação de segurança, se lista vazia será NULL e logo abaixo falharia
-        //acessar "NULL->nodeValue", por isso gera exceção
-        if ($element === NULL) {
-            throw new nfephpException("Erro ao recuperar elemento DOM \"$nome\" pois item(0) retornou NULL, verifique!!");
-        }
-        //se elemento não estiver vazio retorna o seu conteúdo/valor
-        if (! empty($element->nodeValue)) {
-            return $node->nodeValue;
-        }
-        //elemento está vazio, retorna o parâmetro recebido para usar neste caso
-        return $valorSeVazio;
-    }
 }

--- a/libs/NFe/DanfeNFePHP.class.php
+++ b/libs/NFe/DanfeNFePHP.class.php
@@ -59,7 +59,7 @@
 
 //define o caminho base da instalação do sistema
 if (!defined('PATH_ROOT')) {
-    define('PATH_ROOT', dirname(dirname(FILE)) . DIRECTORY_SEPARATOR);
+    define('PATH_ROOT', dirname(dirname(dirname(FILE))).DIRECTORY_SEPARATOR);
 }
 //ajuste do tempo limite de resposta do processo
 set_time_limit(1800);
@@ -335,9 +335,9 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
     protected $debugMode=2;
 
     /**
-     *construct
-     * @name construct
-     * @param string $docXML Arquivo XML da NFe (com ou sem a tag nfeProc)
+     * __construct
+     * @name __construct
+     * @param string $docXML Conteúdo XML da NF-e (com ou sem a tag nfeProc)
      * @param string $sOrientacao (Opcional) Orientação da impressão P-retrato L-Paisagem
      * @param string $sPapel Tamanho do papel (Ex. A4)
      * @param string $sPathLogo Caminho para o arquivo do logo
@@ -412,8 +412,12 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
             $this->tpEmis     = $this->ide->getElementsByTagName("tpEmis")->item(0)->nodeValue;
             $this->tpImp      = $this->ide->getElementsByTagName("tpImp")->item(0)->nodeValue;
             $this->infProt    = $this->dom->getElementsByTagName("infProt")->item(0);
+            //valida se o XML é uma NF-e modelo 55, pois não pode ser 65 (NFC-e)
+            if ($this->pSimpleGetValue($this->ide, "mod") != '55') {
+                throw new nfephpException("O xml do DANFE deve ser uma NF-e modelo 55");
+            }
         }
-    } //fim construct
+    } //fim __construct
 
     /**
      * simpleConsistencyCheck


### PR DESCRIPTION
"getElementsByTagNameOpcional()" pois o mesmo é similar ao
CommonNFePHP::pSimpleGetValue().
2) A classe Tools agora estende a classe Common para aproveitar as
funcionalidades da mesma.
3) Corrigido erro no método signXML() da classe Tools referente
elemento ID, gerava rejeição 297 no evento de cancelamento.
4) Classe Tools, melhorias no método autoriza() e correção da geração
do arquivo na pasta temporárias, referente sufixo "-prot".
5) Classe Tools, demais melhorias simples não relevantes.
6) Classe Common, melhorias no método ŚimpleGetValue().
7) Classe do DANFE, melhorias simples não relevantes.
8) Melhorias e correções diversas na classe DacceNFePHP.
