### PR TITLE
Ajustes na MakeNFePHP

### DIFF
--- a/exemplos/NFe/testeMontaNFe.php
+++ b/exemplos/NFe/testeMontaNFe.php
@@ -2,7 +2,7 @@
 
 require_once('../../libs/NFe/MakeNFePHP.class.php');
 
-$nfe = new MakeNFe();
+$nfe = new MakeNFe(false);
 
 //criar as tags em sequencia 
 
@@ -16,10 +16,10 @@ $cUF = '35'; //codigo numerico do estado
 $cNF = '76037739'; //numero aleatório da NF
 $natOp = 'VENDA DE PRODUTO'; //natureza da operação
 $indPag = '0'; //0=Pagamento à vista; 1=Pagamento a prazo; 2=Outros
-$mod = '65'; //modelo da NFe 55 ou 65 essa última NFCe
+$mod = '55'; //modelo da NFe 55 ou 65 essa última NFCe
 $serie = '0'; //serie da NFe
 $nNF = '28005'; // numero da NFe
-$dhEmi = '2014-02-03';  //para versão 3.00 '2014-02-03T13:22:42-3.00' não informar para NFCe
+$dhEmi = '2014-02-03T13:22:42-3.00';  //para versão 3.00 '2014-02-03T13:22:42-3.00' não informar para NFCe
 $dhSaiEnt = '2014-02-03'; //versão 2.00, 3.00 e 3.10
 $tpNF = '1';
 $idDest = '1'; //1=Operação interna; 2=Operação interestadual; 3=Operação com exterior.
@@ -122,7 +122,7 @@ $CNPJ = '10702368000155';
 $CPF = '';
 $idEstrangeiro = '';
 $xNome = 'M R SANTOS DE PAULA TECIDOS ME';
-$indIEDest = '';
+$indIEDest = '1';
 $IE = '244827055110';
 $ISUF = '';
 $IM = '';

--- a/libs/NFe/MakeNFePHP.class.php
+++ b/libs/NFe/MakeNFePHP.class.php
@@ -33,9 +33,9 @@
  * @author      Roberto L. Machado <linux.rlm at gmail dot com>
  * 
  *        CONTRIBUIDORES (em ordem alfabetica):
- * 
- *              Elias Müller <elias at oxigennio dot com dot br>
+ *
  *              Cleiton Perin <cperin20 at gmail dot com>
+ *              Elias Müller <elias at oxigennio dot com dot br>
  *              Marcos Balbi
  * 
  */
@@ -115,11 +115,11 @@ class MakeNFe
      * 
      * @return none
      */
-    public function __construct()
+    public function __construct($formatOutput = true, $preserveWhiteSpace = false)
     {
         $this->dom = new DOMDocument('1.0', 'UTF-8');
-        $this->dom->formatOutput = true;
-        $this->dom->preserveWhiteSpace = false;
+        $this->dom->formatOutput = $formatOutput;
+        $this->dom->preserveWhiteSpace = $preserveWhiteSpace;
     }
     
     /**
@@ -3100,7 +3100,7 @@ class MakeNFe
                 "erro" => "Preenchimento Obrigatório!"
             );
         }
-        if (! empty($content)) {
+        if ($content != "") {
             $temp = $this->dom->createElement($name, $content);
             $parent->appendChild($temp);
         }


### PR DESCRIPTION
Feito ajustes na Classe de exemplo do MakeNFePHP.
Na Classe MakeNFePHP foi passado para o construtor da classe os
parametros, para que o usuário escolha se ele quer que o xml saia
formatado(no caso de text/plain) ou para nao deixar os espacos em
branco.
No Metodo zAddChild, havia um !empty(), porém quando é passado o valor
0, ele identifica como vazio, segundo como esta no Manual do PHP:
http://br2.php.net/manual/pt_BR/function.empty.php
