### PR TITLE
Opção de enviar Path p/ o arquivo de configurações

### DIFF
--- a/libs/NFe/ToolsNFePHP.class.php
+++ b/libs/NFe/ToolsNFePHP.class.php
@@ -247,6 +247,12 @@ class ToolsNFePHP extends CommonNFePHP
      * @see /config/nfe_ws3_modXX.xml (arquivo novo, layout 3.10 da NF-e, onde
      * "XX" é o modelo da NF-e, "55" ou "65")
      */
+    public $configFile='';
+    /**
+     * configFile
+     * Arquivo de configurações config.php
+     * @var string
+     */
     public $xmlURLfile = 'nfe_ws3_mod55.xml';
     /**
      * enableSVAN
@@ -805,10 +811,11 @@ class ToolsNFePHP extends CommonNFePHP
                     'mailREPLYTOname'=>$aConfig['mailREPLYTOname']);
             }
         } else {
+            $this->configFile = (is_file($aConfig)) ? $aConfig : $this->raizDir . 'config' . DIRECTORY_SEPARATOR . 'config.php';
             //testa a existencia do arquivo de configuração
-            if (is_file($this->raizDir.'config'.DIRECTORY_SEPARATOR.'config.php')) {
+            if (is_file($this->configFile)) {
                 //carrega o arquivo de configuração
-                include($this->raizDir.'config'.DIRECTORY_SEPARATOR.'config.php');
+                include($this->configFile);
                 // carrega propriedades da classe com os dados de configuração
                 // a sring $sAmb será utilizada para a construção dos diretorios
                 // dos arquivos de operação do sistema


### PR DESCRIPTION
Adicionada a opção do construtor receber o caminho para o arquivo de configuração (config.php). Mantida a compatibilidade com a utilização até agora.
