### PR TITLE
Variável $entrega não iniciada.

### DIFF
--- a/libs/NFe/MakeNFePHP.class.php
+++ b/libs/NFe/MakeNFePHP.class.php
@@ -88,6 +88,7 @@ class MakeNFe
     private $dest = ''; //DOMNode
     private $enderDest = ''; //DOMNode
     private $retirada = ''; //DOMNode
+    private $entrega = ''; //DOMNode
     private $total = ''; //DOMNode
     private $pag = ''; //DOMNode
     private $cobr = ''; //DOMNode


### PR DESCRIPTION
Só um detalhe que peguei aqui ao submeter o XML.
Deu erro de que não existia '$entrega', na verdade ela não tinha sido iniciada como as demais.
