### PR TITLE
Proposta de alteração ToolsNFe

### DIFF
--- a/libs/NFe/ToolsNFePHP.class.php
+++ b/libs/NFe/ToolsNFePHP.class.php
@@ -4237,7 +4237,7 @@ class ToolsNFePHP extends CommonNFePHP
      * @param    array   $aRetorno variavel passa por referência Array com os dados do certificado
      * @return  boolean true ou false
      */
-    protected function pValidCerts($cert = '', &$aRetorno = '')
+    public function pValidCerts($cert = '', &$aRetorno = '')
     {
         try {
             if ($cert == '') {


### PR DESCRIPTION
Gostaria de propor a alteração do método pLoadCerts que hoje é protected para public a fins de utiliza-lo fora da classe para validação do certificado digital do cliente antes dele necessitar emitir uma NFe, como por exemplo no momento da instalação do certificado fazer a validação do mesmo.
