### PR TITLE
Correção de BUG na hora de saída

### DIFF
--- a/libs/NFe/DanfeNFePHP.class.php
+++ b/libs/NFe/DanfeNFePHP.class.php
@@ -1683,8 +1683,18 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
         $texto = 'HORA DA SAÍDA';
         $aFont = array('font'=>$this->fontePadrao, 'size'=>6, 'style'=>'');
         $this->pTextBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 1, '');
-        $texto = ! empty($this->ide->getElementsByTagName("hSaiEnt")->item(0)->nodeValue) ?
-                $this->ide->getElementsByTagName("hSaiEnt")->item(0)->nodeValue:"";
+        
+        $dhSaiEnt = ! empty($this->ide->getElementsByTagName("dhSaiEnt")->item(0)->nodeValue) ?
+                $this->ide->getElementsByTagName("dhSaiEnt")->item(0)->nodeValue:"";
+                
+        //Separa a data da hora
+        $dhSaiEntSep = explode('T', $dhSaiEnt);
+        $horaSaidaTimeZone = $dhSaiEntSep[1];
+        
+        //Separa a hora do timezone
+        $horaSaidaTimeZoneSep = explode('-', $horaSaidaTimeZone);
+        $texto = $horaSaidaTimeZoneSep[0];
+                
         $aFont = array('font'=>$this->fontePadrao, 'size'=>10, 'style'=>'B');
         $this->pTextBox($x, $y, $w, $h, $texto, $aFont, 'B', 'C', 0, '');
         return ($y + $h);


### PR DESCRIPTION
Atualmente a classe está buscando a hora de saída da tag "ide->hSaiEnt", a mesma é utilizada na NFe 2.0.

Na NFe 3.10 essa tag foi substituída pela tag dhSaiEnt que armazena a data junto da hora e time zone conforme formato abaixo:
2014-11-14T12:00:00-02:00

Percebi que no campo DATA SAÍDA já foi alterada para buscar a data no novo formato da nova versão de XML porém a HORA SAÍDA não.

Alterei o código nas linhas (1687:1696) para a data completa em três partes e adicionei a hora de saída no campo da danfe.
