### PR TITLE
(Correção) Correção do campo nSeqAdic

### DIFF
--- a/libs/NFe/MakeNFePHP.class.php
+++ b/libs/NFe/MakeNFePHP.class.php
@@ -1157,7 +1157,7 @@ class MakeNFe
      * @param string $nItem
      * @param string $nDI
      * @param string $nAdicao
-     * @param string $nSeqAdicC
+     * @param string $nSeqAdic
      * @param string $cFabricante
      * @param string $vDescDI
      * @param string $nDraw
@@ -1167,7 +1167,7 @@ class MakeNFe
         $nItem = '',
         $nDI = '',
         $nAdicao = '',
-        $nSeqAdicC = '',
+        $nSeqAdic = '',
         $cFabricante = '',
         $vDescDI = '',
         $nDraw = ''
@@ -1175,7 +1175,7 @@ class MakeNFe
         $identificador = 'I25 <adi> - ';
         $adi = $this->dom->createElement("adi");
         $this->zAddChild($adi, "nAdicao", $nAdicao, true, $identificador . "[item $nItem] Número da Adição");
-        $this->zAddChild($adi, "nSeqAdicC", $nSeqAdicC, true, $identificador . "[item $nItem] Número sequencial do item dentro da Adição");
+        $this->zAddChild($adi, "nSeqAdic", $nSeqAdic, true, $identificador . "[item $nItem] Número sequencial do item dentro da Adição");
         $this->zAddChild($adi, "cFabricante", $cFabricante, true, $identificador . "[item $nItem] Código do fabricante estrangeiro");
         $this->zAddChild($adi, "vDescDI", $vDescDI, false, $identificador . "[item $nItem] Valor do desconto do item da DI Adição");
         $this->zAddChild($adi, "nDraw", $nDraw, false, $identificador . "[item $nItem] Número do ato concessório de Drawback");


### PR DESCRIPTION
O campo nSeqAdic estava sendo informado errado: "$nSeqAdicC", acredito que quem programou digitou corretamente e o erro está no manual NT2013.005_v1.02, pois conforme eu já estava utilizando na NF-e 2.0 e consta no antigo manual Versão 2.0.2a o correto é: nSeqAdic.

Isso pode ser confirmado ao validar o xml no sefaz rs.
