### PR TITLE
Erro no nome da tag

### DIFF
--- a/libs/NFe/MakeNFePHP.class.php
+++ b/libs/NFe/MakeNFePHP.class.php
@@ -1287,11 +1287,11 @@ class MakeNFe
         $this->zAddChild($veicProd, "pesoL", $pesoL, true, "$identificador [item $nItem] Peso Líquido do veículo");
         $this->zAddChild($veicProd, "pesoB", $pesoB, true, "$identificador [item $nItem] Peso Bruto do veículo");
         $this->zAddChild($veicProd, "nSerie", $nSerie, true, "$identificador [item $nItem] Serial (série) do veículo");
-        $this->zAddChild($veicProd, "tpCpmb", $tpComb, true, "$identificador [item $nItem] Tipo de combustível do veículo");
+        $this->zAddChild($veicProd, "tpComb", $tpComb, true, "$identificador [item $nItem] Tipo de combustível do veículo");
         $this->zAddChild($veicProd, "nMotor", $nMotor, true, "$identificador [item $nItem] Número de Motor do veículo");
         $this->zAddChild($veicProd, "CMT", $cmt, true, "$identificador [item $nItem] Capacidade Máxima de Tração do veículo");
         $this->zAddChild($veicProd, "dist", $dist, true, "$identificador [item $nItem] Distância entre eixos do veículo");
-        $this->zAddChild($veicProd, "anoMd", $anoMod, true, "$identificador [item $nItem] Ano Modelo de Fabricação do veículo");
+        $this->zAddChild($veicProd, "anoMod", $anoMod, true, "$identificador [item $nItem] Ano Modelo de Fabricação do veículo");
         $this->zAddChild($veicProd, "anoFab", $anoFab, true, "$identificador [item $nItem] Ano de Fabricação do veículo");
         $this->zAddChild($veicProd, "tpPint", $tpPint, true, "$identificador [item $nItem] Tipo de Pintura do veículo");
         $this->zAddChild($veicProd, "tpVeic", $tpVeic, true, "$identificador [item $nItem] Tipo de Veículo");
@@ -1301,7 +1301,7 @@ class MakeNFe
         $this->zAddChild($veicProd, "cMod", $cMod, true, "$identificador [item $nItem] Código Marca Modelo do veículo");
         $this->zAddChild($veicProd, "cCorDENATRAN", $cCorDENATRAN, true, "$identificador [item $nItem] Código da Cor do veículo");
         $this->zAddChild($veicProd, "lota", $lota, true, "$identificador [item $nItem] Capacidade máxima de lotação do veículo");
-        $this->zAddChild($veicProd, "tpResp", $tpRest, true, "$identificador [item $nItem] Restrição do veículo");
+        $this->zAddChild($veicProd, "tpRest", $tpRest, true, "$identificador [item $nItem] Restrição do veículo");
         $this->aVeicProd[$nItem] = $veicProd;
         return $veicProd;
     }


### PR DESCRIPTION
As tags tpCpmb, anoMd e tpResp não constam no leiaute 3.10 da NFe
(Não sei no caso do leiaute 2.0 pois não vou utilizar, por favor verifique antes de juntar)
