### PR TITLE
Remove a formatacao do telefone do destinatario/remetente

### DIFF
--- a/libs/NFe/DanfeNFePHP.class.php
+++ b/libs/NFe/DanfeNFePHP.class.php
@@ -1655,8 +1655,7 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
         $texto = 'FONE / FAX';
         $aFont = array('font'=>$this->fontePadrao, 'size'=>6, 'style'=>'');
         $this->pTextBox($x, $y, $w, $h, $texto, $aFont, 'T', 'L', 1, '');
-        $texto = ! empty($this->dest->getElementsByTagName("fone")->item(0)->nodeValue) ?
-                $this->pFormat($this->dest->getElementsByTagName("fone")->item(0)->nodeValue, '(##) ####-####') : '';
+        $texto = $this->dest->getElementsByTagName("fone")->item(0)->nodeValue;
         $aFont = array('font'=>$this->fontePadrao, 'size'=>10, 'style'=>'B');
         $this->pTextBox($x, $y, $w, $h, $texto, $aFont, 'B', 'C', 0, '');
         //INSCRIÇÃO ESTADUAL


### PR DESCRIPTION
Há algumas semanas, percebi um problema com telefones de 9 dígitos no emissor. O mesmo problema existe no telefone do destinatário, e apliquei a mesma solução para o problema: removi a formatação do telefone.