### PR TITLE
[UPD] NFe. Esperando retorno Autorizacao Lote cStat 215. Alterado chamad...

### DIFF
--- a/libs/NFe/ReturnNFe.php
+++ b/libs/NFe/ReturnNFe.php
@@ -155,9 +155,13 @@ class ReturnNFe
             return $aResposta;
         }
         $dhRecbto = $tag->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
-        $nRec = $tag->getElementsByTagName('nRec')->item(0)->nodeValue;
-        $tMed = $tag->getElementsByTagName('tMed')->item(0)->nodeValue;
-        $aProt[] = self::zProt($tag);
+        $nRec = !empty($tag->getElementsByTagName('nRec')->item(0))
+            ? $tag->getElementsByTagName('nRec')->item(0)->nodeValue
+            : '';
+        $tMed = !empty($tag->getElementsByTagName('tMed')->item(0))
+            ? $tag->getElementsByTagName('tMed')->item(0)->nodeValue
+            : '';
+        $aProt[] = self::zGetProt($tag);
         $aResposta = array(
             'bStat' => true,
             'versao' => $tag->getAttribute('versao'),
@@ -202,7 +206,7 @@ class ReturnNFe
         $dhRecbto = $tag->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
         $tagProt = $tag->getElementsByTagName('protNFe');
         foreach ($tagProt as $protocol) {
-            $aProt[] = self::zProt($protocol);
+            $aProt[] = self::zGetProt($protocol);
         }
         $aResposta = array(
             'bStat'=>true,


### PR DESCRIPTION
* Quando lote não autorizado:
```xml
<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
<soapenv:Header>
<nfeCabecMsg xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeAutorizacao">
<cUF>50</cUF>
<versaoDados>3.10</versaoDados>
</nfeCabecMsg>
</soapenv:Header>
<soapenv:Body>
<nfeAutorizacaoLoteResult xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeAutorizacao">
<retEnviNFe xmlns="http://www.portalfiscal.inf.br/nfe" versao="3.10">
<tpAmb>2</tpAmb>
<verAplic>MS.SPRINGS-20140922</verAplic>
<cStat>215</cStat>
<xMotivo>Rejeicao: Falha no schema XML.</xMotivo>
<cUF>50</cUF>
<dhRecbto>2015-02-24T15:50:38-04:00</dhRecbto>
</retEnviNFe>
</nfeAutorizacaoLoteResult>
</soapenv:Body>
</soapenv:Envelope>
```
Então, ainda não possui nó "nRec" e "tMed".

* Método "zProt" não existe.