### PR TITLE
[UPD] Esperando quando Retorno Autorizacao Lote possui Rejeicao

### DIFF
--- a/libs/NFe/ReturnNFe.php
+++ b/libs/NFe/ReturnNFe.php
@@ -519,10 +519,14 @@ class ReturnNFe
         $aProt = array();
         $infProt = $tag->getElementsByTagName('infProt')->item(0);
         if (! empty($infProt)) {
+            $nProt = $infProt->getElementsByTagName('nProt')->item(0)
+                ? $infProt->getElementsByTagName('nProt')->item(0)->nodeValue
+                : '';
+
             $aProt = array(
                 'chNFe' => $infProt->getElementsByTagName('chNFe')->item(0)->nodeValue,
                 'dhRecbto' => $infProt->getElementsByTagName('dhRecbto')->item(0)->nodeValue,
-                'nProt' => $infProt->getElementsByTagName('nProt')->item(0)->nodeValue,
+                'nProt' => $nProt,
                 'digVal' => $infProt->getElementsByTagName('digVal')->item(0)->nodeValue,
                 'cStat' => $infProt->getElementsByTagName('cStat')->item(0)->nodeValue,
                 'xMotivo' => $infProt->getElementsByTagName('xMotivo')->item(0)->nodeValue

--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -243,7 +243,7 @@ class ToolsNFe extends BaseTools
     
     /**
      * addProtocolo
-     * Adiciona o protocolo de autorização de usoda NFe
+     * Adiciona o protocolo de autorização de uso da NFe
      * NOTA: exigência da SEFAZ, a nota somente é válida com o seu respectivo protocolo
      * @param string $pathNFefile
      * @param string $pathProtfile


### PR DESCRIPTION
* Quando retorno de autorização lote possuir rejeição então ainda não existe nó "nProt"
```xml
<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
<soapenv:Header>
<nfeCabecMsg xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeRetAutorizacao">
<cUF>50</cUF>
<versaoDados>3.10</versaoDados>
</nfeCabecMsg>
</soapenv:Header>
<soapenv:Body>
<nfeRetAutorizacaoLoteResult xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeRetAutorizacao">
<retConsReciNFe xmlns="http://www.portalfiscal.inf.br/nfe" versao="3.10">
<tpAmb>2</tpAmb>
<verAplic>MS.SPRINGS-20140922</verAplic>
<nRec>500150000032417</nRec>
<cStat>104</cStat>
<xMotivo>Lote processado</xMotivo>
<cUF>50</cUF>
<dhRecbto>2015-02-25T14:36:18-04:00</dhRecbto>
<cMsg>0001</cMsg>
<xMsg>NOTA FISCAL ELETRONICA - SEFAZ MS</xMsg>
<protNFe versao="3.10">
<infProt>
<tpAmb>2</tpAmb>
<verAplic>MS.SPRINGS-20140922</verAplic>
<chNFe>50150214203563000191550010000004021550410165</chNFe>
<dhRecbto>2015-02-25T14:36:18-04:00</dhRecbto>
<digVal>G9irkUPMR/UcC7Ezg0EzVQzndtk=</digVal>
<cStat>685</cStat>
<xMotivo>Rejeicao: Total do Valor Aproximado dos Tributos</xMotivo>
</infProt>
</protNFe>
</retConsReciNFe>
</nfeRetAutorizacaoLoteResult>
</soapenv:Body>
</soapenv:Envelope>
```

* nfephp-org/nfephp/libs/NFe/ToolsNFe.php. Apenas gramática no comentário.
