### PR TITLE
[UPD] #392 NFe DANFE. Alterando condicao de (se vazio) para (n. nos na l...

### DIFF
--- a/libs/NFe/DanfeNFePHP.class.php
+++ b/libs/NFe/DanfeNFePHP.class.php
@@ -3074,7 +3074,7 @@ class DanfeNFePHP extends CommonNFePHP implements DocumentoNFePHP
         $formaNfpRef = "\r\nNFP Ref.: série:%d número:%d emit:%s em %s modelo: %d IE:%s";
         $saida='';
         $nfRefs = $this->ide->getElementsByTagName('NFref');
-        if (empty($nfRefs)) {
+        if (0 === $nfRefs->length) {
             return $saida;
         }
         foreach ($nfRefs as $nfRef) {


### PR DESCRIPTION
DOMDocument::getElementsByTagName sempre retorna DOMNodeList. Objetivo com o função a empty falha sempre pois nunca é verdadeiro, mesmo se encontrar ou não o nó. Usando propriedade http://de2.php.net/manual/en/class.domnodelist.php para comparar.