### PR TITLE
[UPD] NFe Retorno Inutizacao

### DIFF
--- a/libs/NFe/ReturnNFe.php
+++ b/libs/NFe/ReturnNFe.php
@@ -378,9 +378,9 @@ class ReturnNFe
         $aResposta['cStat'] = $tag->getElementsByTagName('cStat')->item(0)->nodeValue;
         $aResposta['xMotivo'] = $tag->getElementsByTagName('xMotivo')->item(0)->nodeValue;
         $aResposta['cUF'] = $tag->getElementsByTagName('cUF')->item(0)->nodeValue;
+        $aResposta['dhRecbto'] = $tag->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
         $infInut = $tag->getElementsByTagName('infInut')->item(0);
-        if (! empty($infInut)) {
-            $aResposta['dhRecbto'] = $infInut->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
+        if (! empty($infInut) && 'ID' !== $infInut->getAttribute('Id')) {
             $aResposta['ano'] = $infInut->getElementsByTagName('ano')->item(0)->nodeValue;
             $aResposta['CNPJ'] = $infInut->getElementsByTagName('CNPJ')->item(0)->nodeValue;
             $aResposta['mod'] = $infInut->getElementsByTagName('mod')->item(0)->nodeValue;


### PR DESCRIPTION
Tanto com ou sem Rejeição a tag **dhRecbto** é retornada.

Commit corrigindo acesso a nós (Todos dentro da condição if. L: 383) que não existem quando retorno possui rejeição.

Retorno rejeitado:
```xml
<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
<soapenv:Header>
<nfeCabecMsg xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeInutilizacao2">
<cUF>50</cUF>
<versaoDados>3.10</versaoDados>
</nfeCabecMsg>
</soapenv:Header>
<soapenv:Body>
<nfeInutilizacaoNF2Result xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeInutilizacao2">
<retInutNFe xmlns="http://www.portalfiscal.inf.br/nfe" versao="3.10">
<infInut Id="ID">
<tpAmb>2</tpAmb>
<verAplic>MS.SPRINGS-20140922</verAplic>
<cStat>256</cStat>
<xMotivo>
Rejeicao: Uma NF-e da faixa ja esta inutilizada na Base de dados da SEFAZ
</xMotivo>
<cUF>50</cUF>
<dhRecbto>2015-03-02T15:03:09-04:00</dhRecbto>
</infInut>
</retInutNFe>
</nfeInutilizacaoNF2Result>
</soapenv:Body>
</soapenv:Envelope>
```

Retorno autorizado:
```xml
<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
<soapenv:Header>
<nfeCabecMsg xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeInutilizacao2">
<cUF>50</cUF>
<versaoDados>3.10</versaoDados>
</nfeCabecMsg>
</soapenv:Header>
<soapenv:Body>
<nfeInutilizacaoNF2Result xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/NfeInutilizacao2">
<retInutNFe xmlns="http://www.portalfiscal.inf.br/nfe" versao="3.10">
<infInut Id="ID150150000018514">
<tpAmb>2</tpAmb>
<verAplic>MS.SPRINGS-20140922</verAplic>
<cStat>102</cStat>
<xMotivo>Inutilizacao de numero homologado</xMotivo>
<cUF>50</cUF>
<ano>15</ano>
<CNPJ>14203563000191</CNPJ>
<mod>55</mod>
<serie>1</serie>
<nNFIni>161</nNFIni>
<nNFFin>162</nNFFin>
<dhRecbto>2015-03-02T14:57:55-04:00</dhRecbto>
<nProt>150150000018514</nProt>
</infInut>
</retInutNFe>
</nfeInutilizacaoNF2Result>
</soapenv:Body>
</soapenv:Envelope>
```

Não sei se é a melhor solução de acordo com as regras e retornos. Pode se também comparar cada um dos nós.