### PR TITLE
Tanto o CTe como o Danfe sao mais resistendes a datas sem horario

### DIFF
--- a/libs/CTe/DacteNFePHP.class.php
+++ b/libs/CTe/DacteNFePHP.class.php
@@ -353,9 +353,9 @@ class DacteNFePHP extends CommonNFePHP implements DocumentoNFePHP
      * durante sua construção.
      * A definição de margens e posições iniciais para a impressão são estabelecidas no
      * pelo conteúdo da funçao e podem ser modificados.
-     * 
+     *
      * TODO: Orientação LANDSCAPE
-     * 
+     *
      * @param  string $orientacao (Opcional) Estabelece a orientação da
      *                impressão (ex. P-retrato), se nada for fornecido será
      *                usado o padrão da NFe
@@ -1031,7 +1031,11 @@ class DacteNFePHP extends CommonNFePHP implements DocumentoNFePHP
 
         } else {
             $texto = $this->pSimpleGetValue($this->protCTe, "nProt") . " - ";
-            $texto .= date('d/m/Y   H:i:s', $this->pConvertTime($this->pSimpleGetValue($this->protCTe, "dhRecbto")));
+
+            // empty($volume->getElementsByTagName("qVol")->item(0)->nodeValue)
+            if( !empty($this->protCTe) &&  !empty($this->protCTe->getElementsByTagName("dhRecbto")->item(0)->nodeValue) ){
+                $texto .= date('d/m/Y   H:i:s', $this->pConvertTime($this->pSimpleGetValue($this->protCTe, "dhRecbto")));
+            }
             $texto = $this->pSimpleGetValue($this->protCTe, "nProt") == '' ? '' : $texto;
         }
         $aFont = $this->formatNegrito;
@@ -1230,7 +1234,7 @@ class DacteNFePHP extends CommonNFePHP implements DocumentoNFePHP
      * @param number $xInic  Posição horizontal canto esquerdo
      * @param number $yFinal Posição vertical final para impressão
      */
-    private function zRodape($x, $y)
+    protected function zRodape($x, $y)
     {
         $texto = "Impresso em  " . date('d/m/Y   H:i:s');
         $w = $this->wPrint - 4;
@@ -2087,7 +2091,7 @@ class DacteNFePHP extends CommonNFePHP implements DocumentoNFePHP
 
     /**
      * zGeraChaveAdicCont
-     *   
+     *
      * @return string chave
      */
     protected function zGeraChaveAdicCont()
@@ -2264,10 +2268,10 @@ class DacteNFePHP extends CommonNFePHP implements DocumentoNFePHP
     /**
      * zDocCompl
      * Monta o campo com os dados do remetente na DACTE.
-     * 
+     *
      * @param number $x Posição horizontal canto esquerdo
      * @param number $y Posição vertical canto superior
-     * @return number Posição vertical final 
+     * @return number Posição vertical final
      */
     protected function zDocCompl($x = 0, $y = 0)
     {

--- a/libs/Common/CommonNFePHP.class.php
+++ b/libs/Common/CommonNFePHP.class.php
@@ -32,7 +32,7 @@
  *
  *        CONTRIBUIDORES (por ordem alfabetica):
  *          Fernando Mertins <fernando dot mertins at gmail dot com>
- *          Roberto L. Machado <linux dot rlm at gmail dot com> 
+ *          Roberto L. Machado <linux dot rlm at gmail dot com>
  *
  * Esta classe depende de PdfNFePHP.class.php e deve ser utilizada pelas classes DanfeNFePHP e DacteNFePHP
  */
@@ -80,7 +80,7 @@ class CommonNFePHP
             return;
         }
     }
-    
+
     /**
      * pSimpleGetValue
      * Extrai o valor do node DOM
@@ -179,8 +179,8 @@ class CommonNFePHP
 
     /**
      * pConvertTime
-     * Converte a imformação de data e tempo contida na NFe
-     * 
+     * Converte a informação de data e tempo contida na NFe
+     *
      * @param string $DH Informação de data e tempo extraida da NFe
      * @return timestamp UNIX Para uso com a funçao date do php
      */
@@ -191,9 +191,13 @@ class CommonNFePHP
         }
         $aDH = explode('T', $DH);
         $adDH = explode('-', $aDH[0]);
-        $inter = explode('-', $aDH[1]);
-        $atDH = explode(':', $inter[0]);
-        $timestampDH = mktime($atDH[0], $atDH[1], $atDH[2], $adDH[1], $adDH[2], $adDH[0]);
+        if( count($aDH) > 1 ){
+            $inter = explode('-', $aDH[1]);
+            $atDH = explode(':', $inter[0]);
+            $timestampDH = mktime($atDH[0], $atDH[1], $atDH[2], $adDH[1], $adDH[2], $adDH[0]);
+        }else{
+            $timestampDH = mktime($month = $adDH[1], $day =  $adDH[2], $year = $adDH[0]);
+        }
         return $timestampDH;
     }
 
@@ -289,7 +293,7 @@ class CommonNFePHP
     /**
      * pGetNumLines
      * Obtem o numero de linhas usadas pelo texto usando a fonte especifidada
-     * 
+     *
      * @param string $text
      * @param number $width
      * @param array $aFont
@@ -322,8 +326,8 @@ class CommonNFePHP
      * @param string $hAlign Alinhamento horizontal do texto, L-esquerda, C-centro, R-direita
      * @param boolean $border TRUE ou 1 desenha a borda, FALSE ou 0 Sem borda
      * @param string $link Insere um hiperlink
-     * @param boolean $force Se for true força a caixa com uma unica linha 
-     * e para isso atera o tamanho do fonte até caber no espaço, 
+     * @param boolean $force Se for true força a caixa com uma unica linha
+     * e para isso atera o tamanho do fonte até caber no espaço,
      * se falso mantem o tamanho do fonte e usa quantas linhas forem necessárias
      * @param number $hmax
      * @param number $vOffSet incremento forçado na na posição Y
@@ -456,8 +460,8 @@ class CommonNFePHP
      * @param string $hAlign Alinhamento horizontal do texto, L-esquerda, C-centro, R-direita
      * @param boolean $border TRUE ou 1 desenha a borda, FALSE ou 0 Sem borda
      * @param string $link Insere um hiperlink
-     * @param boolean $force Se for true força a caixa com uma unica 
-     * linha e para isso atera o tamanho do fonte até caber no espaço, 
+     * @param boolean $force Se for true força a caixa com uma unica
+     * linha e para isso atera o tamanho do fonte até caber no espaço,
      * se falso mantem o tamanho do fonte e usa quantas linhas forem necessárias
      * @param number $hmax
      * @param number $vOffSet incremento forçado na na posição Y


### PR DESCRIPTION
Alteração Principal:

- Danfe e Dacte são não geram warnings nem erros com datas sem hora ( YYYY-MM-DD )

Alterções secundárias:
- erro de ortografia nos comentários
- dei trim em todas as linhas ( o sublime edit faz automático )
- protected function zRodape no dacte agora é protected para ficar consistente com o Danfe.