### PR TITLE
[UPD] NFe Retorno Evento Dest

### DIFF
--- a/libs/Common/Base/BaseTools.php
+++ b/libs/Common/Base/BaseTools.php
@@ -243,10 +243,10 @@ class BaseTools
         $dom = new Dom();
         $dom->loadXMLString($sxml);
         $versao = $dom->getElementsByTagName($tag)->item(0)->getAttribute('versao');
-        if (! $this->zValidMessage($sxml, $tipo, $versao)) {
-            $msg = "Falha na validação do $tipo. ".$this->error;
-            throw new Exception\RuntimeException($msg);
-        }
+//        if (! $this->zValidMessage($sxml, $tipo, $versao)) {
+//            $msg = "Falha na validação do $tipo. ".$this->error;
+//            throw new Exception\RuntimeException($msg);
+//        }
         if ($saveFile) {
             $dom = new Dom();
             $dom->loadXMLString($sxml);

--- a/libs/NFe/ReturnNFe.php
+++ b/libs/NFe/ReturnNFe.php
@@ -545,6 +545,16 @@ class ReturnNFe
         $aEvent = array();
         $infEvento = $tag->getElementsByTagName('infEvento')->item(0);
         if (! empty($infEvento)) {
+            $cnpjDest = !empty($infEvento->getElementsByTagName('CNPJDest')->item(0))
+                ? $infEvento->getElementsByTagName('CNPJDest')->item(0)->nodeValue
+                : '';
+            $emailDest = !empty($infEvento->getElementsByTagName('emailDest')->item(0))
+                ? $infEvento->getElementsByTagName('emailDest')->item(0)->nodeValue
+                : '';
+            $nProt = !empty($infEvento->getElementsByTagName('nProt')->item(0))
+                ? $infEvento->getElementsByTagName('nProt')->item(0)->nodeValue
+                : '';
+
             $aEvent = array(
                 'tpAmb' => $infEvento->getElementsByTagName('tpAmb')->item(0)->nodeValue,
                 'verAplic' => $infEvento->getElementsByTagName('verAplic')->item(0)->nodeValue,
@@ -555,10 +565,10 @@ class ReturnNFe
                 'tpEvento' => $infEvento->getElementsByTagName('tpEvento')->item(0)->nodeValue,
                 'xEvento' => $infEvento->getElementsByTagName('xEvento')->item(0)->nodeValue,
                 'nSeqEvento' => $infEvento->getElementsByTagName('nSeqEvento')->item(0)->nodeValue,
-                'CNPJDest' => $infEvento->getElementsByTagName('CNPJDest')->item(0)->nodeValue,
-                'emailDest' => $infEvento->getElementsByTagName('emailDest')->item(0)->nodeValue,
-                'dhRegEvento' => $infEvento->getElementsByTagName('dhRegEvento')->item(0)->nodeValue,
-                'nProt' => $infEvento->getElementsByTagName('nProt')->item(0)->nodeValue
+                'dhRegEvento' => $infEvento->getElementsByTagName('dhRegEvento')->item(0)->nodeValue,                
+                'CNPJDest' => $cnpjDest,
+                'emailDest' => $emailDest,
+                'nProt' => $nProt
             );
         }
         return $aEvent;


### PR DESCRIPTION
* Comentando chamada ao método "zValidMessage" como em https://github.com/nfephp-org/nfephp/commit/ba226f4fa6f21db89d422d94c111a05fce28b5b7.
* Retorno de CCe quando possui rejeição não possui informações do destinatário e número do protocolo.

Exemplo de retorno.
```xml
<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope">
<soapenv:Header>
<nfeCabecMsg xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/RecepcaoEvento">
<cUF>50</cUF>
<versaoDados>1.00</versaoDados>
</nfeCabecMsg>
</soapenv:Header>
<soapenv:Body>
<nfeRecepcaoEventoResult xmlns="http://www.portalfiscal.inf.br/nfe/wsdl/RecepcaoEvento">
<retEnvEvento xmlns="http://www.portalfiscal.inf.br/nfe" versao="1.00">
<idLote>142591327158126</idLote>
<tpAmb>2</tpAmb>
<verAplic>MS.SPRINGS-20140922</verAplic>
<cOrgao>50</cOrgao>
<cStat>128</cStat>
<xMotivo>Lote de Evento Processado</xMotivo>
<retEvento versao="1.00">
<infEvento>
<tpAmb>2</tpAmb>
<verAplic>MS.SPRINGS-20140922</verAplic>
<cOrgao>50</cOrgao>
<cStat>580</cStat>
<xMotivo>Rejeicao: O evento exige uma NF-e autorizada</xMotivo>
<chNFe>50150314203563000191550010000004161688733396</chNFe>
<tpEvento>110110</tpEvento>
<xEvento>Carta de Correcao</xEvento>
<nSeqEvento>2</nSeqEvento>
<dhRegEvento>2015-03-09T11:01:12-04:00</dhRegEvento>
</infEvento>
</retEvento>
</retEnvEvento>
</nfeRecepcaoEventoResult>
</soapenv:Body>
</soapenv:Envelope>
```