### PR TITLE
Update ToolsNFe.php

### DIFF
--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -1415,4 +1415,14 @@ class ToolsNFe extends BaseTools
         }
         return array('alias' => $aliasEvento, 'desc' => $descEvento);
     }
+    
+    /**
+    * getTimestampCert
+    * Retorna o timestamp para a data de vencimento do Certificado
+    * @return int
+    */
+    public function getTimestampCert(){
+      return $this->oCertificate->expireTimestamp;
+    }
+    
 }


### PR DESCRIPTION
Adicionado método getTimestampCert() para obter o timestamp da data de expiração do certificado através de uma instancia da própria ToolsNfe.