### PR TITLE
Consulta Emissão contra o CNPJ e Danfe NFCe

### DIFF
--- a/libs/NFe/DanfeNFCeNFePHP.class.php
+++ b/libs/NFe/DanfeNFCeNFePHP.class.php
@@ -49,10 +49,10 @@ if (!defined('PATH_ROOT')) {
 set_time_limit(1800);
 
 //classes utilizadas
-require_once '../../libs/External/mpdf/mpdf.php';
-require_once '../../libs/External/qrcode/qrcode.class.php';
-require_once '../../libs/Common/CommonNFePHP.class.php';
-require_once '../../libs/Common/DocumentoNFePHP.interface.php';
+require_once PATH_ROOT . 'libs/External/mpdf/mpdf.php';
+require_once PATH_ROOT . 'libs/External/qrcode/qrcode.class.php';
+require_once PATH_ROOT . 'libs/Common/CommonNFePHP.class.php';
+require_once PATH_ROOT . 'libs/Common/DocumentoNFePHP.interface.php';
 
 /**
  * Classe DanfceNFePHP

--- a/libs/NFe/ToolsNFePHP.class.php
+++ b/libs/NFe/ToolsNFePHP.class.php
@@ -2692,7 +2692,7 @@ class ToolsNFePHP extends CommonNFePHP
                     $chNFe = $resNFe->getElementsByTagName('chNFe')->item(0)->nodeValue;
                     $CNPJ = $resNFe->getElementsByTagName('CNPJ')->item(0)->nodeValue;
                     $xNome = $resNFe->getElementsByTagName('xNome')->item(0)->nodeValue;
-                    $dhEmi = $resNFe->getElementsByTagName('dhEmi')->item(0)->nodeValue;
+                    //$dhEmi = $resNFe->getElementsByTagName('dhEmi')->item(0)->nodeValue;
                     $dhRecbto= $resNFe->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
                     $tpNF = $resNFe->getElementsByTagName('tpNF')->item(0)->nodeValue;
                     $cSitNFe = $resNFe->getElementsByTagName('cSitNFe')->item(0)->nodeValue;
@@ -2702,7 +2702,7 @@ class ToolsNFePHP extends CommonNFePHP
                         'NSU'=>$nsu,
                         'CNPJ'=>$CNPJ,
                         'xNome'=>$xNome,
-                        'dhEmi'=>$dhEmi,
+                        //'dhEmi'=>$dhEmi,
                         'dhRecbto'=>$dhRecbto,
                         'tpNF'=>$tpNF,
                         'cSitNFe'=>$cSitNFe,
@@ -2715,7 +2715,7 @@ class ToolsNFePHP extends CommonNFePHP
                     $chNFe = $resCanc->getElementsByTagName('chNFe')->item(0)->nodeValue;
                     $CNPJ = $resCanc->getElementsByTagName('CNPJ')->item(0)->nodeValue;
                     $xNome = $resCanc->getElementsByTagName('xNome')->item(0)->nodeValue;
-                    $dhEmi = $resCanc->getElementsByTagName('dhEmi')->item(0)->nodeValue;
+                    //$dhEmi = $resCanc->getElementsByTagName('dhEmi')->item(0)->nodeValue;
                     $dhRecbto= $resCanc->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
                     $tpNF = $resCanc->getElementsByTagName('tpNF')->item(0)->nodeValue;
                     $cSitNFe = $resCanc->getElementsByTagName('cSitNFe')->item(0)->nodeValue;
@@ -2725,7 +2725,7 @@ class ToolsNFePHP extends CommonNFePHP
                         'NSU'=>$nsu,
                         'CNPJ'=>$CNPJ,
                         'xNome'=>$xNome,
-                        'dhEmi'=>$dhEmi,
+                        //'dhEmi'=>$dhEmi,
                         'dhRecbto'=>$dhRecbto,
                         'tpNF'=>$tpNF,
                         'cSitNFe'=>$cSitNFe,
@@ -4651,7 +4651,7 @@ class ToolsNFePHP extends CommonNFePHP
             curl_setopt($oCurl, CURLOPT_PORT, 443);
             curl_setopt($oCurl, CURLOPT_VERBOSE, 1);
             curl_setopt($oCurl, CURLOPT_HEADER, 1); //retorna o cabeçalho de resposta
-            //curl_setopt($oCurl, CURLOPT_SSLVERSION, 3);
+            curl_setopt($oCurl, CURLOPT_SSLVERSION, 3);
             curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 2); // verifica o host evita MITM
             curl_setopt($oCurl, CURLOPT_SSL_VERIFYPEER, 0);
             curl_setopt($oCurl, CURLOPT_SSLCERT, $this->certKEY);

--- a/libs/NFe/ToolsNFePHP.class.php
+++ b/libs/NFe/ToolsNFePHP.class.php
@@ -2692,7 +2692,8 @@ class ToolsNFePHP extends CommonNFePHP
                     $chNFe = $resNFe->getElementsByTagName('chNFe')->item(0)->nodeValue;
                     $CNPJ = $resNFe->getElementsByTagName('CNPJ')->item(0)->nodeValue;
                     $xNome = $resNFe->getElementsByTagName('xNome')->item(0)->nodeValue;
-                    //$dhEmi = $resNFe->getElementsByTagName('dhEmi')->item(0)->nodeValue;
+                    $dEmi = $resNFe->getElementsByTagName('dEmi')->item(0)->nodeValue;
+                    $vNF = $resNFe->getElementsByTagName('vNF')->item(0)->nodeValue;
                     $dhRecbto= $resNFe->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
                     $tpNF = $resNFe->getElementsByTagName('tpNF')->item(0)->nodeValue;
                     $cSitNFe = $resNFe->getElementsByTagName('cSitNFe')->item(0)->nodeValue;
@@ -2702,7 +2703,8 @@ class ToolsNFePHP extends CommonNFePHP
                         'NSU'=>$nsu,
                         'CNPJ'=>$CNPJ,
                         'xNome'=>$xNome,
-                        //'dhEmi'=>$dhEmi,
+                        'dEmi'=>$dEmi,
+                        'vNF'=>$vNF,
                         'dhRecbto'=>$dhRecbto,
                         'tpNF'=>$tpNF,
                         'cSitNFe'=>$cSitNFe,
@@ -2715,7 +2717,8 @@ class ToolsNFePHP extends CommonNFePHP
                     $chNFe = $resCanc->getElementsByTagName('chNFe')->item(0)->nodeValue;
                     $CNPJ = $resCanc->getElementsByTagName('CNPJ')->item(0)->nodeValue;
                     $xNome = $resCanc->getElementsByTagName('xNome')->item(0)->nodeValue;
-                    //$dhEmi = $resCanc->getElementsByTagName('dhEmi')->item(0)->nodeValue;
+                    $dEmi = $resCanc->getElementsByTagName('dEmi')->item(0)->nodeValue;
+                    $vNF = $resCanc->getElementsByTagName('vNF')->item(0)->nodeValue;
                     $dhRecbto= $resCanc->getElementsByTagName('dhRecbto')->item(0)->nodeValue;
                     $tpNF = $resCanc->getElementsByTagName('tpNF')->item(0)->nodeValue;
                     $cSitNFe = $resCanc->getElementsByTagName('cSitNFe')->item(0)->nodeValue;
@@ -2725,7 +2728,8 @@ class ToolsNFePHP extends CommonNFePHP
                         'NSU'=>$nsu,
                         'CNPJ'=>$CNPJ,
                         'xNome'=>$xNome,
-                        //'dhEmi'=>$dhEmi,
+                        'dEmi'=>$dEmi,
+                        'vNF'=>$vNF,
                         'dhRecbto'=>$dhRecbto,
                         'tpNF'=>$tpNF,
                         'cSitNFe'=>$cSitNFe,


### PR DESCRIPTION
Ajuste no retorno da consulta das notas emitidas contra o cnpj não estava buscando as informações corretas e algumas faltavam.
Na biblioteca danfe nfce não estava conforme a danfe nfe a requirec_once dos documentos gerando problema na utilização com o composer
