### PR TITLE
correção de bug, ao passar um lote de NF-es a inicialização da variavel ...

### DIFF
--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -501,13 +501,11 @@ class ToolsNFe extends BaseTools
             throw new Exception\InvalidArgumentException($msg);
         }
         if (is_array($aXml)) {
-            foreach ($aXml as $xml) {
-                $sxml .= $xml;
-            }
             if (count($aXml) > 1) {
                 //multiplas nfes, não pode ser sincrono
                 $indSinc = 0;
             }
+            $sxml = implode("", $sxml);
         }
         $sxml = preg_replace("/<\?xml.*\?>/", "", $sxml);
         $siglaUF = $this->aConfig['siglaUF'];


### PR DESCRIPTION
...$sxml com o array, ao montar XML inserindo a string "Array" incorretamente no XML.
Além de causar um NOTICE.

Resultado antes da correção:
```
<idLote>142851035635480</idLote>
<indSinc>0</indSinc>
Array
<NFe>
```