### PR TITLE
[UPD] ToolsNFePHP.class.php - Inclusão da opção cURL para apenas resolve...

### DIFF
--- a/libs/NFe/ToolsNFePHP.class.php
+++ b/libs/NFe/ToolsNFePHP.class.php
@@ -4657,7 +4657,8 @@ class ToolsNFePHP extends CommonNFePHP
             curl_setopt($oCurl, CURLOPT_PORT, 443);
             curl_setopt($oCurl, CURLOPT_VERBOSE, 1);
             curl_setopt($oCurl, CURLOPT_HEADER, 1); //retorna o cabeçalho de resposta
-            curl_setopt($oCurl, CURLOPT_SSLVERSION, 3);
+            curl_setopt($oCurl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+            //curl_setopt($oCurl, CURLOPT_SSLVERSION, 3);
             curl_setopt($oCurl, CURLOPT_SSL_VERIFYHOST, 2); // verifica o host evita MITM
             curl_setopt($oCurl, CURLOPT_SSL_VERIFYPEER, 0);
             curl_setopt($oCurl, CURLOPT_SSLCERT, $this->certKEY);


### PR DESCRIPTION
...r endereços IPV4, devido a problemas com o DNS de MT e GO e comentado a opção do cURL para forçar SSLv3 devido a que alguns autorizadores estarem usando outros protocolos como o TLSv1.00. Deve ser usado o PHP mais atualizado e as bibliotecas libssl mais atualizadas para permitir a identificação do protocolo de encriptação durante o handshake com o servidor