### PR TITLE
composer.json version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "zendframework/zend-barcode": "2.3.4",
         "zendframework/zend-mail": "2.3.*@dev",
         "soundasleep/html2text": "~0.2",
-        "mpdf/mpdf": "dev-master",
+        "mpdf/mpdf": "~6.0",
         "endroid/qrcode": "1.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
composer.json

```json
{
    "name": "olavocn/test-composer-nfephp",
    "require": {
        "nfephp-org/nfephp": "dev-develop"
    },
    "license": "MIT",
    "authors": [
        {
            "name": "Olavo Neto",
            "email": "olavocn.neto@gmail.com"
        }
    ],
    "minimum-stability": "stable"
}
```
Rodando: **composer install -o**

```bash
Loading composer repositories with package information
Installing dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for nfephp-org/nfephp dev-develop -> satisfiable by nfephp-org/nfephp[dev-develop].
    - nfephp-org/nfephp dev-develop requires mpdf/mpdf dev-master -> no matching package found.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```

Acredito que isso acontece quando estou com versão anterior ao commit: https://github.com/nfephp-org/nfephp/commit/2e30a663727739e1afce13362787a2c0c49beca0. Em contra partida na versão atual:
```bash
git pull *** develop
composer update -o 

  - Installing mpdf/mpdf (dev-master 69d1abd)
    Cloning 69d1abdde39b5341c53c1498af4625f414f04625
```

Alguém saberia me explicar tecnicamente o que aconteceu?