### PR TITLE
[UPD] ToolsNFe.php - Corrige o problema de ao consultar por chave e a…

### DIFF
--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -401,7 +401,8 @@ class ToolsNFe extends BaseTools
         //pode ser um evento ou resultado de uma consulta com multiplos eventos
         $doccanc = new Dom();
         $doccanc->loadXMLFile($pathCancfile);
-        $eventos = $doccanc->getElementsByTagName('infEvento');
+        $retEvento = $doccanc->getElementsByTagName('retEvento')->item(0);
+        $eventos = $retEvento->getElementsByTagName('infEvento');
         foreach ($eventos as $evento) {
             //evento
             $cStat = $evento->getElementsByTagName('cStat')->item(0)->nodeValue;


### PR DESCRIPTION
…dicionar o procolo,

quando a nota esta cancelada, ele busca a segunda infEvento dentro de
retEvento que é o correto - Colaboração de Eduardo Gusmão