### PR TITLE
Correção de rejeição 493 para o evento de manifestação de desconhecimento

### DIFF
--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -1676,7 +1676,7 @@ class ToolsNFe extends BaseTools
             case '210240':
                 //Operacao não Realizada
                 $aliasEvento = 'EvNaoRealizada';
-                $descEvento = 'Operacao não Realizada';
+                $descEvento = 'Operacao nao Realizada';
                 break;
             default:
                 $msg = "O código do tipo de evento informado não corresponde a "


### PR DESCRIPTION
Correção do texto referente ao campo descEvento da manifestação do destinatário que possui caractere acentuado incompatível com o schema, gerando a rejeição 493 ao realizar manifesto de desconhecimento.