### PR TITLE
[UPD] Correção em MakeNFe.php - NT.2015.002_V1.00 Para a NFC-e, se am…

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -47,7 +47,7 @@ class MakeNFe extends BaseMake
      * @var string
      */
     public $chNFe = '';
-    
+      
     //propriedades privadas utilizadas internamente pela classe
     private $NFe = ''; //DOMNode
     private $infNFe = ''; //DOMNode
@@ -239,7 +239,7 @@ class MakeNFe extends BaseMake
         $cDV = '',
         $tpAmb = '',
         $finNFe = '',
-        $indFinal = '',
+        $indFinal = '0',
         $indPres = '',
         $procEmi = '',
         $verProc = '',
@@ -1233,6 +1233,9 @@ class MakeNFe extends BaseMake
         $nItemPed = '',
         $nFCI = ''
     ) {
+        if ($this->tpAmb == '2' && $nItem == 1) {
+            $xProd = 'NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
+        }
         $identificador = 'I01 <prod> - ';
         $prod = $this->dom->createElement("prod");
         $this->dom->addChild(


### PR DESCRIPTION
…biente de homologação (tag:tpAmb=2, id:B24):

- Descrição do primeiro item da Nota Fiscal (tag:xProd) deve ser
informada como “NOTA FISCAL EMITIDA EM AMBIENTE DE
HOMOLOGACAO - SEM VALOR FISCAL”