### PR TITLE
[UPD] schemas/NFe/PL_008g/tiposBasico_v3.10.xsd - Corrigida a express…

### DIFF
--- a/schemes/NFe/PL_008g/tiposBasico_v3.10.xsd
+++ b/schemes/NFe/PL_008g/tiposBasico_v3.10.xsd
@@ -800,7 +800,7 @@ acrescentado:
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TData">


### PR DESCRIPTION
…ão regular TString de: [!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1} para para: [!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}