### PR TITLE
Erro no acesso à pasta da imagem do QrCode

### DIFF
--- a/libs/Extras/Danfce.php
+++ b/libs/Extras/Danfce.php
@@ -801,7 +801,12 @@ class Danfce extends CommonNFePHP implements DocumentoNFePHP
                ->setLabel('')
                ->setLabelFontSize(16);
         $img = $qrCode->get();
-        $filename = '../../images/'.date('YmdHis').'.jpg';
+        
+        if(!is_dir('images'))
+        {
+            mkdir('images', 0777);
+        }
+        $filename = 'images/'.date('YmdHis').'.jpg';
         file_put_contents($filename, $img);
         return $filename;
     }


### PR DESCRIPTION
Na implementação do nfephp para um cliente, o arquivo que instancia a classe da danfce.php se encontrava na pasta raiz do servidor, quando chamamos a classe da danfe, esta passa a executar no nível do arquivo que a chamou e não no nível onde ela se encontra atualmente, o que fez com que a linha: "../../" fosse inacessível, outros problemas também quando a pasta não existia, portanto foi necessário verificar se a pasta existia, caso não existisse: criá-la!
E usar um caminho mais próximo do que DOIS NÍVEIS acima pois em alguns casos isso não é possível.
Esta correção parece resolver o problema.