### PR TITLE
[UPD] vICMSUFDest validacao , no milhar

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -4078,9 +4078,9 @@ class MakeNFe extends BaseMake
         }
         //ajuste de digitos dos campos totalizados
         if ($this->aTotICMSUFDest['vICMSUFDest'] != '') {
-            $this->aTotICMSUFDest['vICMSUFDest'] = number_format($this->aTotICMSUFDest['vICMSUFDest'], 2);
-            $this->aTotICMSUFDest['vICMSUFRemet'] = number_format($this->aTotICMSUFDest['vICMSUFRemet'], 2);
-            $this->aTotICMSUFDest['vFCPUFDest'] = number_format($this->aTotICMSUFDest['vFCPUFDest'], 2);
+            $this->aTotICMSUFDest['vICMSUFDest'] = number_format($this->aTotICMSUFDest['vICMSUFDest'], 2, '.', '');
+            $this->aTotICMSUFDest['vICMSUFRemet'] = number_format($this->aTotICMSUFDest['vICMSUFRemet'], 2, '.', '');
+            $this->aTotICMSUFDest['vFCPUFDest'] = number_format($this->aTotICMSUFDest['vFCPUFDest'], 2, '.', '');
         }
     }
     


### PR DESCRIPTION
Quando envia uma nota com partilha maior que 1000.00 ele por 1,000.00 e da erro de validação, so acertando o number_format para retirar o sinal no milhar