### PR TITLE
[UPD] danfe se perde no numero de paginas

### DIFF
--- a/libs/Extras/Danfe.php
+++ b/libs/Extras/Danfe.php
@@ -703,6 +703,7 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
                 $totPag++;
                 $hDispo = $hDispo2;
                 $hUsado = 7;
+                $i--; // decrementa para readicionar o item que não coube nessa pagina na outra.
             }
             $i++;
         } //fim da soma das areas de itens usadas


### PR DESCRIPTION
Danfe se perde no numero de páginas,

```php
while ($i < $this->det->length) {
            $texto = $this->pDescricaoProduto($this->det->item($i));
            $numlinhas = $this->pGetNumLines($texto, $w2, $fontProduto);
            $hUsado += round(($numlinhas * $this->pdf->FontSize) + ($numlinhas * 0.5), 2);
            if ($hUsado > $hDispo) {
                $totPag++;
                $hDispo = $hDispo2;
                $hUsado = 7;
            }
            $i++;
        } //fim da soma das areas de itens usadas

```

nesse while ele conta o numero de página, porem desconsidera que quando ultrapassa o disponivel vai utilizar o mesmo produto na outra página então tem que decrementar o $i pra considerar o produto de novo na próxima página

Exemplo da página bugada, 1/2 2/2 e 3/3
[35160112980968000100550010000062701564635011-danfe.pdf](https://github.com/nfephp-org/nfephp/files/110067/35160112980968000100550010000062701564635011-danfe.pdf)
