### PR TITLE
A exigência do CNPJ 99999999000191 não existe mais para Homologação

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -788,7 +788,6 @@ class MakeNFe extends BaseMake
         }
         if ($this->tpAmb == '2' && $this->mod == '55') {
             $xNome = 'NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
-            $cnpj = '99999999000191';
         }
         if ($cnpj != '') {
             $this->dom->addChild(

--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -788,6 +788,7 @@ class MakeNFe extends BaseMake
         }
         if ($this->tpAmb == '2' && $this->mod == '55') {
             $xNome = 'NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
+            //a exigência do CNPJ 99999999000191 não existe mais
         }
         if ($cnpj != '') {
             $this->dom->addChild(


### PR DESCRIPTION
Já havia feito isso antes e acabou sendo esquecido e retornou ao código