### PR TITLE
Correção de cálculo de altura e quebra de página

### DIFF
--- a/libs/Extras/Danfe.php
+++ b/libs/Extras/Danfe.php
@@ -702,7 +702,7 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
             if ($hUsado > $hDispo) {
                 $totPag++;
                 $hDispo = $hDispo2;
-                $hUsado = 7;
+                $hUsado = $hCabecItens;
                 $i--; // decrementa para readicionar o item que não coube nessa pagina na outra.
             }
             $i++;
@@ -735,7 +735,7 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
         $y = $this->pTransporteDANFE($x, $y+1);
         //itens da DANFE
         $nInicial = 0;
-        $y = $this->pItensDANFE($x, $y+1, $nInicial, $hDispo1, $pag, $totPag);
+        $y = $this->pItensDANFE($x, $y+1, $nInicial, $hDispo1, $pag, $totPag, $hCabecItens);
         //coloca os dados do ISSQN
         if ($linhaISSQN == 1) {
             $y = $this->pIssqnDANFE($x, $y+4);
@@ -766,7 +766,7 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
             //coloca o cabeçalho na página adicional
             $y = $this->pCabecalhoDANFE($x, $y, $n, $totPag);
             //coloca os itens na página adicional
-            $y = $this->pItensDANFE($x, $y+1, $nInicial, $hDispo2, $pag, $totPag);
+            $y = $this->pItensDANFE($x, $y+1, $nInicial, $hDispo2, $pag, $totPag, $hCabecItens);
             //coloca o rodapé da página
             if ($this->orientacao == 'P') {
                 $this->pRodape($xInic, $y + 4);
@@ -2290,7 +2290,7 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
      * @param float $hmax Altura máxima do campo de itens em mm
      * @return float Posição vertical final
      */
-    protected function pItensDANFE($x, $y, &$nInicio, $hmax, $pag = 0, $totpag = 0)
+    protected function pItensDANFE($x, $y, &$nInicio, $hmax, $pag = 0, $totpag = 0, $hCabecItens = 7)
     {
         $oldX = $x;
         $oldY = $y;
@@ -2418,7 +2418,7 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
         //##################################################################################
         // LOOP COM OS DADOS DOS PRODUTOS
         $i = 0;
-        $hUsado = 4;
+        $hUsado = $hCabecItens;
         $aFont = array('font'=>$this->fontePadrao, 'size'=>7, 'style'=>'');
         foreach ($this->det as $d) {
             if ($i >= $nInicio) {


### PR DESCRIPTION
No loop da linha 698, o total da altura era minimamente maior que o disponível, em nosso caso, 57.45 para 57 disponíveis. Isso criava uma nova página, todavia, o problema era que nesta segunda página os itens eram uma repetição dos itens da primeira página, ou seja, duplicavam.

Analisando o código chegamos a diversos valores que eram relacionados, mas absolutos e que definiam a altura do cabeçalho da tabela de produtos, o qual no código para a segunda página era 7, enquanto iniciava como 4 e na função que gerava os itens também era 4 (linha 2421).

Esta alteração regulariza todos e inclui o valor como parâmetro da função. Regularizando todos os itens com altura usada de 7 ao invés de 4 criou a paginação correta em nossos testes.