### PR TITLE
Correção número de sequência do arquivo xml NFeCC

### DIFF
--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -1856,11 +1856,12 @@ class ToolsNFe extends BaseTools
                 $pasta = 'eventos'; //default
                 if ($aliasEvento == 'CancNFe') {
                     $pasta = 'canceladas';
+                    $filename = "$chNFe-$aliasEvento-procEvento.xml";
                 } elseif ($aliasEvento == 'CCe') {
                     $pasta = 'cartacorrecao';
+                    $filename = "$chNFe-$aliasEvento-$nSeqEvento-procEvento.xml";
                 }
                 $retorno = $this->zAddProtMsg('procEventoNFe', 'evento', $signedMsg, 'retEvento', $retorno);
-                $filename = "$chNFe-$aliasEvento-procEvento.xml";
                 $this->zGravaFile('nfe', $tpAmb, $filename, $retorno, $pasta);
             }
         }


### PR DESCRIPTION
Alterado para registrar o número de sequencia da carta de correção no arquivo físico pois ao enviar mais de uma carta de correção por NF-e, o arquivo xml físico estava sendo substituído pelo novo.

Nome antigo:
`42160407527420000170550020000000711322763000-CCe-procEvento.xml`

Novos nomes:
```
42160407527420000170550020000000711322763000-CCe-1-procEvento.xml
42160407527420000170550020000000711322763000-CCe-2-procEvento.xml
42160407527420000170550020000000711322763000-CCe-3-procEvento.xml
42160407527420000170550020000000711322763000-CCe-4-procEvento.xml
```