### PR TITLE
Atualização dos endereços das WebServices do SEFAZ GO, e Implementação do recurso de Administração do CSC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ local
 /phpunit.xml
 /tests/folder
 .coverage
-
+xmls

--- a/config/nfe_ws3_mod55.xml
+++ b/config/nfe_ws3_mod55.xml
@@ -91,22 +91,34 @@ AM Consulta de Cadastro não EXISTE
   <UF>
     <sigla>GO</sigla>
     <homologacao>
-      <NfeAutorizacao method="nfeAutorizacaoLote" operation="NfeAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeAutorizacao</NfeAutorizacao>
-      <NfeConsultaCadastro method="cadConsultaCadastro2" operation="CadConsultaCadastro2" version="2.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/CadConsultaCadastro2</NfeConsultaCadastro>
-      <NfeConsultaProtocolo method="nfeConsultaNF2" operation="NfeConsulta2" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeConsulta2</NfeConsultaProtocolo>
-      <NfeInutilizacao method="nfeInutilizacaoNF2" operation="NfeInutilizacao2" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeInutilizacao2</NfeInutilizacao>
-      <NfeRetAutorizacao method="nfeRetAutorizacaoLote" operation="NfeRetAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeRetAutorizacao</NfeRetAutorizacao>
-      <NfeStatusServico method="nfeStatusServicoNF2" operation="NfeStatusServico2" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeStatusServico2</NfeStatusServico>
-      <RecepcaoEvento method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/RecepcaoEvento</RecepcaoEvento>
+       <RecepcaoEvento method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/RecepcaoEvento</RecepcaoEvento>
+       <NfeRecepcao method="nfeRecepcao2" operation="Recepcao2" version="2.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeRecepcao2</NfeRecepcao>
+       <NfeRetRecepcao method="nfeRetRecepcao2" operation="RecepcaoEvento" version="2.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeRetRecepcao2</NfeRetRecepcao>
+       <NfeInutilizacao method="nfeInutilizacao2" operation="NfeInutilizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeInutilizacao2</NfeInutilizacao>
+       <NfeConsultaProtocolo method="nfeConsulta2" operation="NfeConsultaProtocolo" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeConsulta2</NfeConsultaProtocolo>
+       <NfeStatusServico method="nfeStatusServico2" operation="NfeStatusServico" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeStatusServico2</NfeStatusServico>
+       <NfeConsultaCadastro method="consultaCadastro2" operation="NfeConsultaCadastro" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/CadConsultaCadastro2</NfeConsultaCadastro>       
+       <NfeAutorizacao method="nfeAutorizacao" operation="NfeAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeAutorizacao</NfeAutorizacao>
+       <NfeRetAutorizacao method="nfeRetAutorizacao" operation="NfeRetAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeRetAutorizacao</NfeRetAutorizacao>
+       <CscNFCe method="admCscNFCe" operation="CscNFCe" version="1.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/CscNFCe</CscNFCe>       
+       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100"></NfeConsultaQR>
+       <NfeConsultaDest method="nfeConsultaNFDest" operation="NfeConsultaDest" version="3.10"></NfeConsultaDest>
+       <NfeDownloadNF method="nfeDownloadNF" operation="NfeDownloadNF" version="3.10"></NfeDownloadNF>
     </homologacao>
     <producao>
-      <NfeAutorizacao method="nfeAutorizacaoLote" operation="NfeAutorizacao" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeAutorizacao</NfeAutorizacao>
-      <NfeConsultaCadastro method="cadConsultaCadastro2" operation="CadConsultaCadastro2" version="2.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/CadConsultaCadastro2</NfeConsultaCadastro>
-      <NfeConsultaProtocolo method="nfeConsultaNF2" operation="NfeConsulta2" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeConsulta2</NfeConsultaProtocolo>
-      <NfeInutilizacao method="nfeInutilizacaoNF2" operation="NfeInutilizacao2" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeInutilizacao2</NfeInutilizacao>
-      <NfeRetAutorizacao method="nfeRetAutorizacaoLote" operation="NfeRetAutorizacao" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeRetAutorizacao</NfeRetAutorizacao>
-      <NfeStatusServico method="nfeStatusServicoNF2" operation="NfeStatusServico2" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeStatusServico2</NfeStatusServico>
-      <RecepcaoEvento method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/RecepcaoEvento</RecepcaoEvento>
+       <RecepcaoEvento method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/RecepcaoEvento</RecepcaoEvento>
+       <NfeRecepcao method="nfeRecepcao2" operation="Recepcao2" version="2.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeRecepcao2</NfeRecepcao>
+       <NfeRetRecepcao method="nfeRetRecepcao2" operation="RecepcaoEvento" version="2.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeRetRecepcao2</NfeRetRecepcao>
+       <NfeInutilizacao method="nfeInutilizacao2" operation="NfeInutilizacao" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeInutilizacao2</NfeInutilizacao>
+       <NfeConsultaProtocolo method="nfeConsulta2" operation="NfeConsultaProtocolo" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeConsulta2</NfeConsultaProtocolo>
+       <NfeStatusServico method="nfeStatusServico2" operation="NfeStatusServico" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeStatusServico2</NfeStatusServico>
+       <NfeConsultaCadastro method="consultaCadastro2" operation="NfeConsultaCadastro" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/CadConsultaCadastro2</NfeConsultaCadastro>       
+       <NfeAutorizacao method="nfeAutorizacao" operation="NfeAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeAutorizacao</NfeAutorizacao>
+       <NfeRetAutorizacao method="nfeRetAutorizacao" operation="NfeRetAutorizacao" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeRetAutorizacao</NfeRetAutorizacao>
+       <CscNFCe method="admCscNFCe" operation="CscNFCe" version="1.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/CscNFCe</CscNFCe>       
+       <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100"></NfeConsultaQR>
+       <NfeConsultaDest method="nfeConsultaNFDest" operation="NfeConsultaDest" version="3.10"></NfeConsultaDest>
+       <NfeDownloadNF method="nfeDownloadNF" operation="NfeDownloadNF" version="3.10"></NfeDownloadNF>
     </producao>
   </UF>
   <UF>

--- a/config/nfe_ws3_mod65.xml
+++ b/config/nfe_ws3_mod65.xml
@@ -148,32 +148,34 @@ ATENÇÃO!!! Vários endereços destes webservices ainda não foram totalmente
   <UF>
     <sigla>GO</sigla>
     <homologacao>
-       <NfeAutorizacao method="nfeAutorizacaoLote" operation="NfeAutorizacao" version="3.10"></NfeAutorizacao>
-       <NfeRetAutorizacao method="nfeRetAutorizacaoLote" operation="NfeRetAutorizacao" version="3.10"></NfeRetAutorizacao>
-       <NfeInutilizacao  method="nfeInutilizacaoNF2" operation="NfeInutilizacao2" version="3.10"></NfeInutilizacao>
-       <NfeConsultaProtocolo method="nfeConsultaNF2" operation="NfeConsulta2" version="3.10"></NfeConsultaProtocolo>
-       <NfeStatusServico method="nfeStatusServicoNF2" operation="NfeStatusServico2" version="3.10"></NfeStatusServico>
-       <RecepcaoEvento  method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00"></RecepcaoEvento>
+       <RecepcaoEvento method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/RecepcaoEvento</RecepcaoEvento>
+       <NfeRecepcao method="nfeRecepcao2" operation="Recepcao2" version="2.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeRecepcao2</NfeRecepcao>
+       <NfeRetRecepcao method="nfeRetRecepcao2" operation="RecepcaoEvento" version="2.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeRetRecepcao2</NfeRetRecepcao>
+       <NfeInutilizacao method="nfeInutilizacao2" operation="NfeInutilizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeInutilizacao2</NfeInutilizacao>
+       <NfeConsultaProtocolo method="nfeConsulta2" operation="NfeConsultaProtocolo" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeConsulta2</NfeConsultaProtocolo>
+       <NfeStatusServico method="nfeStatusServico2" operation="NfeStatusServico" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeStatusServico2</NfeStatusServico>
+       <NfeConsultaCadastro method="consultaCadastro2" operation="NfeConsultaCadastro" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/CadConsultaCadastro2</NfeConsultaCadastro>       
+       <NfeAutorizacao method="nfeAutorizacao" operation="NfeAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeAutorizacao</NfeAutorizacao>
+       <NfeRetAutorizacao method="nfeRetAutorizacao" operation="NfeRetAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeRetAutorizacao</NfeRetAutorizacao>
+       <CscNFCe method="admCscNFCe" operation="CscNFCe" version="1.00">https://homolog.sefaz.go.gov.br/nfe/services/v2/CscNFCe</CscNFCe>       
        <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100"></NfeConsultaQR>
-       <NfeConsultaCadastro method="consultaCadastro2" operation="NfeConsultaCadastro" version="3.10"></NfeConsultaCadastro>
        <NfeConsultaDest method="nfeConsultaNFDest" operation="NfeConsultaDest" version="3.10"></NfeConsultaDest>
        <NfeDownloadNF method="nfeDownloadNF" operation="NfeDownloadNF" version="3.10"></NfeDownloadNF>
-       <RecepcaoEPEC method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00"></RecepcaoEPEC>
-       <NfeStatusEPEC method="nfeStatusServicoNF2" operation="NfeStatusServico2" version="3.10"></NfeStatusEPEC>       
     </homologacao>
     <producao>
-       <NfeAutorizacao method="nfeAutorizacaoLote" operation="NfeAutorizacao" version="3.10"></NfeAutorizacao>
-       <NfeRetAutorizacao method="nfeRetAutorizacaoLote" operation="NfeRetAutorizacao" version="3.10"></NfeRetAutorizacao>
-       <NfeInutilizacao  method="nfeInutilizacaoNF2" operation="NfeInutilizacao2" version="3.10"></NfeInutilizacao>
-       <NfeConsultaProtocolo method="nfeConsultaNF2" operation="NfeConsulta2" version="3.10"></NfeConsultaProtocolo>
-       <NfeStatusServico method="nfeStatusServicoNF2" operation="NfeStatusServico2" version="3.10"></NfeStatusServico>
-       <RecepcaoEvento  method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00"></RecepcaoEvento>
+       <RecepcaoEvento method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/RecepcaoEvento</RecepcaoEvento>
+       <NfeRecepcao method="nfeRecepcao2" operation="Recepcao2" version="2.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeRecepcao2</NfeRecepcao>
+       <NfeRetRecepcao method="nfeRetRecepcao2" operation="RecepcaoEvento" version="2.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeRetRecepcao2</NfeRetRecepcao>
+       <NfeInutilizacao method="nfeInutilizacao2" operation="NfeInutilizacao" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeInutilizacao2</NfeInutilizacao>
+       <NfeConsultaProtocolo method="nfeConsulta2" operation="NfeConsultaProtocolo" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeConsulta2</NfeConsultaProtocolo>
+       <NfeStatusServico method="nfeStatusServico2" operation="NfeStatusServico" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeStatusServico2</NfeStatusServico>
+       <NfeConsultaCadastro method="consultaCadastro2" operation="NfeConsultaCadastro" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/CadConsultaCadastro2</NfeConsultaCadastro>       
+       <NfeAutorizacao method="nfeAutorizacao" operation="NfeAutorizacao" version="3.10">https://homolog.sefaz.go.gov.br/nfe/services/v2/NfeAutorizacao</NfeAutorizacao>
+       <NfeRetAutorizacao method="nfeRetAutorizacao" operation="NfeRetAutorizacao" version="3.10">https://nfe.sefaz.go.gov.br/nfe/services/v2/NfeRetAutorizacao</NfeRetAutorizacao>
+       <CscNFCe method="admCscNFCe" operation="CscNFCe" version="1.00">https://nfe.sefaz.go.gov.br/nfe/services/v2/CscNFCe</CscNFCe>       
        <NfeConsultaQR method="QR-CODE" operation="NfeConsultaQR" version="100"></NfeConsultaQR>
-       <NfeConsultaCadastro method="consultaCadastro2" operation="NfeConsultaCadastro" version="3.10"></NfeConsultaCadastro>
        <NfeConsultaDest method="nfeConsultaNFDest" operation="NfeConsultaDest" version="3.10"></NfeConsultaDest>
        <NfeDownloadNF method="nfeDownloadNF" operation="NfeDownloadNF" version="3.10"></NfeDownloadNF>
-       <RecepcaoEPEC method="nfeRecepcaoEvento" operation="RecepcaoEvento" version="1.00"></RecepcaoEPEC>
-       <NfeStatusEPEC method="nfeStatusServicoNF2" operation="NfeStatusServico2" version="3.10"></NfeStatusEPEC>       
     </producao>
   </UF>
   <UF>

--- a/exemplos/NFe/4.00testaAdmCSC.php
+++ b/exemplos/NFe/4.00testaAdmCSC.php
@@ -1,0 +1,32 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 'On');
+include_once '../../bootstrap.php';
+
+use NFePHP\NFe\ToolsNFe;
+
+$nfe = new ToolsNFe('../../config/config.json');
+$nfe->setModelo('65');
+
+/* Operações de administração CSC (indOp):
+
+01 – Consulta
+02 – Solicitação
+03 – Revogação
+
+*/
+
+$indOp = '1';
+$tpAmb = '2';
+$raizCNPJ = ''; // Deixe vazio para utilizar o CNPJ do Certificado
+$idCsc = '1';
+$codigoCsc = '433f0a3dbe4c7720';
+$saveXml = true; // Salva o resultado em XML na pasta csc
+
+$aResposta = array();
+$xml = $nfe->sefazManutencaoCsc($indOp, $tpAmb, $raizCNPJ, $idCsc, $codigoCsc, $saveXml, $aResposta);
+echo '<br><br><PRE>';
+echo htmlspecialchars($nfe->soapDebug);
+echo '</PRE><BR><PRE>';
+print_r($aResposta);
+echo "</PRE><br>";

--- a/install/index.php
+++ b/install/index.php
@@ -432,7 +432,7 @@ function changeAlerts(key, flag, msg) {
     <span title="Indique o Código de Segurança do Contribuinte (antigo Token) para montagem do QRCode nas NFCe, requer cadastramento prévio na SEFAZ">CSC - Código de Segurança do Contribuinte (antigo Token)</span><br>
     <input type="text" id="tokenNFCe" name="tokenNFCe" placeholder="Código de Segurança do Contribuinte (antigo Token) para NFCe"  value="<?php echo $tokenNFCe;?>" /><br>
     <span title="Indique o Identificador do CSC – Código de Segurança do Contribuinte no Banco de Dados da SEFAZ para NFCe, 6 digitos numericos com zeros a esquerda">Identificador do CSC NFCe</span><br>
-    <input type="text" id="tokenNFCeId" name="tokenNFCeId" placeholder="000000" size="8" value="<?php echo $tokenNFCeId;?>" /><br>
+    <input type="text" id="tokenNFCeId" name="tokenNFCeId" placeholder="Identificador do CSC, necessário para validar o CSC." size="8" value="<?php echo $tokenNFCeId;?>" /><br>
     </div>
     <div id="direita">
         <h3>Estes campos referen-se a os dados principais do emitente e todos os campos em amarelo são OBRIGATÓRIOS.</h3>

--- a/libs/Common/Base/BaseTools.php
+++ b/libs/Common/Base/BaseTools.php
@@ -456,6 +456,7 @@ class BaseTools
         } else {
             $aURL = self::zLoadSEFAZ($pathXmlUrlFile, $tpAmb, $siglaUF, $tipo);
         }
+        
         //recuperação da versão
         $this->urlVersion = $aURL[$service]['version'];
         //recuperação da url do serviço
@@ -574,7 +575,7 @@ class BaseTools
             'CE'=>'CE',
             'DF'=>'SVRS',
             'ES'=>'SVRS',
-            'GO'=>'SVRS',
+            'GO'=>'GO',
             'MA'=>'SVRS',
             'MG'=>'MG',
             'MS'=>'MS',
@@ -709,7 +710,7 @@ class BaseTools
             $path = $this->aConfig['pathMDFeFiles'];
         }
         $pathTemp = Files\FilesFolders::getFilePath($tpAmb, $path, $subFolder)
-            . DIRECTORY_SEPARATOR.$anomes;
+            . DIRECTORY_SEPARATOR.$anomes;        
         if (! Files\FilesFolders::saveFile($pathTemp, $filename, $data)) {
             $msg = 'Falha na gravação no diretório. '.$pathTemp;
             throw new Exception\RuntimeException($msg);

--- a/libs/Common/Files/FilesFolders.php
+++ b/libs/Common/Files/FilesFolders.php
@@ -36,7 +36,8 @@ class FilesFolders
         'temporarias',
         'recebidas',
         'consultadas',
-        'pdf'
+        'pdf',
+        'csc'
     );
     
     /**

--- a/libs/NFe/ReturnNFe.php
+++ b/libs/NFe/ReturnNFe.php
@@ -61,6 +61,9 @@ class ReturnNFe
             case 'NfeDownloadNF':
                 return self::zReadDownloadNF($dom);
                 break;
+            case 'CscNFCe':
+                return self::zReadCscNFCe($dom);
+                break;
         }
         return array();
     }
@@ -137,6 +140,47 @@ class ReturnNFe
         $aResposta['xMotivo'] = $dom->getValue($tag, 'xMotivo');
         $aResposta['dhResp'] = $dom->getValue($tag, 'dhResp');
         $aResposta['aRetNFe'] = $aRetNFe;
+        return $aResposta;
+    }
+    
+    /**
+     * zReadCscNFCe
+     * @param DOMDocument $dom
+     * @param boolean $parametro
+     * @return array
+     */
+    protected static function zReadCscNFCe($dom)
+    {
+        //retorno da funçao
+        $aResposta = array(
+            'bStat' => false,
+            'versao' => '',
+            'tpAmb' => '',
+            'indOp' => '',
+            'cStat' => '',
+            'xMotivo' => '',
+            'aRetNFe' => array()
+        );
+        $tag = $dom->getNode('cscNFCeResult');
+        $aRetCSC = array();
+        if (! isset($tag)) {
+            return $aResposta;
+        }
+        $retAdmCscNFCe = $dom->getNode('retAdmCscNFCe');
+        if (! empty($retAdmCscNFCe)) {
+            $aResposta['versao'] = $retAdmCscNFCe->getAttribute('versao');
+        }
+        $dadosCsc = $dom->getNode('dadosCsc');
+        if (! empty($dadosCsc)) {
+            $aResposta['idCsc'] = $dom->getValue($dadosCsc, 'idCsc');
+            $aResposta['codigoCsc'] = $dom->getValue($dadosCsc, 'codigoCsc');
+        }
+        $aResposta['bStat'] = true;
+        $aResposta['tpAmb'] = $dom->getValue($tag, 'tpAmb');
+        $aResposta['indOp'] = $dom->getValue($tag, 'indOp');
+        $aResposta['cStat'] = $dom->getValue($tag, 'cStat');
+        $aResposta['xMotivo'] = $dom->getValue($tag, 'xMotivo');
+        $aResposta['aRetCSC'] = $aRetCSC;
         return $aResposta;
     }
     


### PR DESCRIPTION
As mudanças foram focadas em um recursos que as SEFAZ peca muito em transparência e atendimento ao contribuinte, é a administração do **CSC - Código de Segurança do Contribuinte (Antigo Token da NFC-e)**, no Sergipe onde a NFC-e esta mais desenvolvida você administra no próprio site da SEFAZ já no Amazonas você precisa se direcionar até a SEFAZ, outros estados não as vezes não tem como emitir e sem o CSC não emite NFC-e.

Aqui em Goiás a SEFAZ liberou (não oficialmente ainda, tive acesso através de um contato do TI lá de dentro...) uma WebService para **Administração do CSC**, podendo **Consultar** códigos já emitidos, **Solicitar** nova emissão (até 2 no máximo...) e **Revogar** código emitidos, depois de analisar a estrutura da API eu implementei novos códigos para consumir essa nova WebService [https://homolog.sefaz.go.gov.br/nfe/services/v2/CscNFCe?wsdl](https://homolog.sefaz.go.gov.br/nfe/services/v2/CscNFCe?wsdl).

Testes foram feitos em Ambiente Windows 7 Ultimate, consumindo a WebService da SEFAZ GO utilizando toda as 3 Operações, ocorrendo sucesso em todas, também simulei erros na escrita do XML para verificar se havia novos códigos de erros diferente dos que já existe no manual, os de falha estão documentados no manual mas os de êxito não estão, segue a lista:

Método ToolsNFe: **sefazManutencaoCsc**
Página de Teste: **exemplos/NFe/4.00testaAdmCSC.php**
Pasta dos XMLs: **NFe/homologacao/csc**

- cStat - **213**, xMotivo - **Rejeição: CNPJ-Base do Emitente difere do CNPJ-Base do Certificado Digital**
- cStat - **215**, xMotivo - **Rejeição: Falha no schema XML**
- cStat - **150**, xMotivo - **Consulta de CSC realizada com sucesso, com CSC ativo(s)**
- cStat - **151**, xMotivo - **Consulta de CSC realizada com sucesso, sem CSC ativo(s)**
- cStat - **152**, xMotivo - **CSC gerado**
- cStat - **153**, xMotivo - **CSC revogado**

Como também era necessário para efetuar os testes, as WebServices da SEFAZ GO foram atualizadas tanto no Modelo 55 quanto no Modelo 65 que por regra da própria SEFAZ utilizam os mesmo WebServices ([Informativo](http://www.nfe.go.gov.br/post/ver/199913/nota-fiscal-de-consumidor-eletronica-nfc-e-disponivel-em-ambiente-de-homologacao))

Por questões de organização e novas definições do Manual, foi implementado a criação automática da nova pasta **'csc'** para opcionalmente salvar os xmls das consultas, e na página de instalação da API foi atualizando os termos **"Token NFC-e"** para **"CSC NFC-e"**.