### PR TITLE
Melhoria na função "addProtocolo()"

### DIFF
--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -299,7 +299,13 @@ class ToolsNFe extends BaseTools
     {
         //carrega a NFe
         $docnfe = new Dom();
-        $docnfe->loadXMLFile($pathNFefile);
+        
+        if(file_exists($pathNFefile)){ 
+			$docnfe->loadXMLFile($pathNFefile);
+		}else{
+			$docnfe->loadXMLString($pathNFefile);
+		}
+        
         $nodenfe = $docnfe->getNode('NFe', 0);
         if ($nodenfe == '') {
             $msg = "O arquivo indicado como NFe não é um xml de NFe!";
@@ -311,7 +317,13 @@ class ToolsNFe extends BaseTools
         }
         //carrega o protocolo
         $docprot = new Dom();
-        $docprot->loadXMLFile($pathProtfile);
+        
+        if(file_exists($pathProtfile)){ 
+			$docprot->loadXMLFile($pathProtfile);
+		}else{
+			$docprot->loadXMLString($pathProtfile);
+		}
+        
         $nodeprots = $docprot->getElementsByTagName('protNFe');
         if ($nodeprots->length == 0) {
             $msg = "O arquivo indicado não contem um protocolo de autorização!";

--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -300,10 +300,10 @@ class ToolsNFe extends BaseTools
         //carrega a NFe
         $docnfe = new Dom();
         
-        if(file_exists($pathNFefile)){
+        if (file_exists($pathNFefile)) {
             //carrega o XML pelo caminho do arquivo informado
             $docnfe->loadXMLFile($pathNFefile);
-        }else{
+        } else {
             //carrega o XML pelo conteúdo
             $docnfe->loadXMLString($pathNFefile);
         }
@@ -320,10 +320,10 @@ class ToolsNFe extends BaseTools
         //carrega o protocolo
         $docprot = new Dom();
         
-        if(file_exists($pathProtfile)){
+        if (file_exists($pathProtfile)) {
             //carrega o XML pelo caminho do arquivo informado
             $docprot->loadXMLFile($pathProtfile);
-        }else{
+        } else {
             //carrega o XML pelo conteúdo
             $docprot->loadXMLString($pathProtfile);
         }

--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -300,9 +300,11 @@ class ToolsNFe extends BaseTools
         //carrega a NFe
         $docnfe = new Dom();
         
-        if(file_exists($pathNFefile)){ 
+        if(file_exists($pathNFefile)){
+            //carrega o XML pelo caminho do arquivo informado
 			$docnfe->loadXMLFile($pathNFefile);
 		}else{
+		    //carrega o XML pelo conteúdo
 			$docnfe->loadXMLString($pathNFefile);
 		}
         
@@ -318,9 +320,11 @@ class ToolsNFe extends BaseTools
         //carrega o protocolo
         $docprot = new Dom();
         
-        if(file_exists($pathProtfile)){ 
+        if(file_exists($pathProtfile)){
+            //carrega o XML pelo caminho do arquivo informado
 			$docprot->loadXMLFile($pathProtfile);
 		}else{
+		    //carrega o XML pelo conteúdo
 			$docprot->loadXMLString($pathProtfile);
 		}
         

--- a/libs/NFe/ToolsNFe.php
+++ b/libs/NFe/ToolsNFe.php
@@ -302,11 +302,11 @@ class ToolsNFe extends BaseTools
         
         if(file_exists($pathNFefile)){
             //carrega o XML pelo caminho do arquivo informado
-			$docnfe->loadXMLFile($pathNFefile);
-		}else{
-		    //carrega o XML pelo conteúdo
-			$docnfe->loadXMLString($pathNFefile);
-		}
+            $docnfe->loadXMLFile($pathNFefile);
+        }else{
+            //carrega o XML pelo conteúdo
+            $docnfe->loadXMLString($pathNFefile);
+        }
         
         $nodenfe = $docnfe->getNode('NFe', 0);
         if ($nodenfe == '') {
@@ -322,11 +322,11 @@ class ToolsNFe extends BaseTools
         
         if(file_exists($pathProtfile)){
             //carrega o XML pelo caminho do arquivo informado
-			$docprot->loadXMLFile($pathProtfile);
-		}else{
-		    //carrega o XML pelo conteúdo
-			$docprot->loadXMLString($pathProtfile);
-		}
+            $docprot->loadXMLFile($pathProtfile);
+        }else{
+            //carrega o XML pelo conteúdo
+            $docprot->loadXMLString($pathProtfile);
+        }
         
         $nodeprots = $docprot->getElementsByTagName('protNFe');
         if ($nodeprots->length == 0) {


### PR DESCRIPTION
A melhoria consiste em chamar a função passando o caminho do XML ou o próprio XML, desta forma não é necessário que o arquivo esteja salvo em disco para chamar a função