### PR TITLE
Melhoria para evitar erro fatal

### DIFF
--- a/libs/Extras/Danfe.php
+++ b/libs/Extras/Danfe.php
@@ -423,7 +423,10 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
         $logoAlign = 'C',
         $situacaoExterna = NFEPHP_SITUACAO_EXTERNA_NONE,
         $classPdf = false,
-        $dpecNumReg = ''
+        $dpecNumReg = '',
+        $margSup = 2,
+        $margEsq = 2,
+        $margInf = 2
     ) {
         return $this->montaDANFE(
             $orientacao,
@@ -431,7 +434,10 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
             $logoAlign,
             $situacaoExterna,
             $classPdf,
-            $dpecNumReg
+            $dpecNumReg,
+            $margSup,
+            $margEsq,
+            $margInf
         );
     }//fim monta
 
@@ -465,7 +471,10 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
         $logoAlign = 'C',
         $situacaoExterna = NFEPHP_SITUACAO_EXTERNA_NONE,
         $classPdf = false,
-        $depecNumReg = ''
+        $depecNumReg = '',
+        $margSup = 2,
+        $margEsq = 2,
+        $margInf = 2
     ) {
         //se a orientação estiver em branco utilizar o padrão estabelecido na NF
         if ($orientacao == '') {
@@ -490,9 +499,6 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
         //margens do PDF, em milímetros. Obs.: a margem direita é sempre igual à
         //margem esquerda. A margem inferior *não* existe na FPDF, é definida aqui
         //apenas para controle se necessário ser maior do que a margem superior
-        $margSup = 2;
-        $margEsq = 2;
-        $margInf = 2;
         // posição inicial do conteúdo, a partir do canto superior esquerdo da página
         $xInic = $margEsq;
         $yInic = $margSup;
@@ -3019,9 +3025,9 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
             }
             $refECF = $nfRef->getElementsByTagName('refECF');
             foreach ($refECF as $umaRefNFe) {
-                $mod	= $umaRefNFe->getElementsByTagName('mod')->item(0)->nodeValue;
-                $nECF	= $umaRefNFe->getElementsByTagName('nECF')->item(0)->nodeValue;
-                $nCOO	= $umaRefNFe->getElementsByTagName('nCOO')->item(0)->nodeValue;
+                $mod    = $umaRefNFe->getElementsByTagName('mod')->item(0)->nodeValue;
+                $nECF   = $umaRefNFe->getElementsByTagName('nECF')->item(0)->nodeValue;
+                $nCOO   = $umaRefNFe->getElementsByTagName('nCOO')->item(0)->nodeValue;
                 $saida .= sprintf($formaECFRef, $mod, $nECF, $nCOO);
             }
             $refNFP = $nfRef->getElementsByTagName('refNFP');

--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -2139,7 +2139,9 @@ class MakeNFe extends BaseMake
                 break;
         }
         $tagIcms = $this->dom->createElement('ICMS');
-        $tagIcms->appendChild($icms);
+        if(isset($icms)){
+            $tagIcms->appendChild($icms);
+        }
         $this->aICMS[$nItem] = $tagIcms;
         return $tagIcms;
     }
@@ -2470,7 +2472,9 @@ class MakeNFe extends BaseMake
         } else {
             $tagIcms = $this->dom->createElement('ICMS');
         }
-        $this->dom->appChild($tagIcms, $icmsSN, "Inserindo ICMSST em ICMS[$nItem]");
+        if(isset($icmsSN)){
+            $this->dom->appChild($tagIcms, $icmsSN, "Inserindo ICMSST em ICMS[$nItem]");
+        }
         $this->aICMS[$nItem] = $tagIcms;
         return $tagIcms;
     }
@@ -2734,7 +2738,9 @@ class MakeNFe extends BaseMake
                 break;
         }
         $pis = $this->dom->createElement('PIS');
-        $pis->appendChild($pisItem);
+        if(isset($pisItem)){
+            $pis->appendChild($pisItem);
+        }
         $this->aPIS[$nItem] = $pis;
         return $pis;
     }
@@ -2839,7 +2845,9 @@ class MakeNFe extends BaseMake
                 break;
         }
         $confins = $this->dom->createElement('COFINS');
-        $confins->appendChild($confinsItem);
+        if(isset($confinsItem)){
+            $confins->appendChild($confinsItem);
+        }
         $this->aCOFINS[$nItem] = $confins;
         return $confins;
     }


### PR DESCRIPTION
Adicionado verificação nas situações onde existe switch para evitar erro fatal quando o CST passado em branco ou inválido não entra em nenhuma das situações do switch.

Caso contrário o sistema tentava adicionar um elemento DOM null dentro de outro elemento.