### PR TITLE
Implementação do método higienizarString na classe BaseMake.

### DIFF
--- a/libs/Common/Base/BaseMake.php
+++ b/libs/Common/Base/BaseMake.php
@@ -154,4 +154,23 @@ class BaseMake
     {
         return Keys::buildKey($cUF, $ano, $mes, $cnpj, $mod, $serie, $numero, $tpEmis, $codigo);
     }
+    
+    /**
+     * higienizarString
+     * Substitui caracteres acentuados por não acentuados, 
+     * remove acentos e caracateres especiais (exceto ', &, < e >),
+     * troca os caracteres: > (sinal de maior), < (sinal de menor),
+     * & (e-comercial) e ' (sinal de apóstrofe) em HTML,
+     * remove espaços do inicio e final da string.
+     *
+     * @param string $string
+     * @return string
+     */
+    function higienizarString($string)
+    {
+        $string = preg_replace( '/[`^"~]/', NULL, iconv( 'UTF-8', 'ASCII//TRANSLIT', $string ) );
+        $string = htmlspecialchars( $string , ENT_QUOTES);
+        $string = trim( $string );
+        return $string;
+    }
 }


### PR DESCRIPTION
Método mais eficiente para substituir o uso htmlspecialchars() na construção do XML.

Substitui caracteres acentuados por não acentuados, remove acentos e caracteres especiais (exceto ', &, < e >), troca os caracteres: > (sinal de maior), < (sinal de menor), & (e-comercial) e ' (sinal de apóstrofe) em HTML, remove espaços do inicio e final da string.

```
Entrada: R$ â £ ¢ ë Ä ~ e ( ] ç ª , = % 2 # @ & " ' < >
Saída: R$ a lb c e A  e ( ] c a , = % 2 # @ &amp;  &#039; &lt; &gt;
```