### PR TITLE
schema não aceita emitir

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -3339,8 +3339,11 @@ class MakeNFe extends BaseMake
         $siglaUF = ''
     ) {
         $transporta = $this->dom->createElement("transporta");
-        $this->dom->addChild($transporta, "CNPJ", $numCNPJ, false, "CNPJ do Transportador");
-        $this->dom->addChild($transporta, "CPF", $numCPF, false, "CPF do Transportador");
+        if (!empty($numCNPJ)) {
+            $this->dom->addChild($transporta, "CNPJ", $numCNPJ, false, "CNPJ do Transportador");
+        } else {
+            $this->dom->addChild($transporta, "CPF", $numCPF, false, "CPF do Transportador");
+        }
         $this->dom->addChild($transporta, "xNome", $xNome, false, "Razão Social ou nome do Transportador");
         $this->dom->addChild($transporta, "IE", $numIE, false, "Inscrição Estadual do Transportador");
         $this->dom->addChild($transporta, "xEnder", $xEnder, false, "Endereço Completo do Transportador");


### PR DESCRIPTION
a validação não aceitava emitir de forma alguma pois a TAG CPF aparecia em branco e esta não deveria existir.
notei que no SPED-NFE está com o mesmo problema. Sugiro esta correção ou outra melhor que permita emitir.