### PR TITLE
[UPD] Ajuste na Classe Dom 

### DIFF
--- a/libs/Common/Dom/Dom.php
+++ b/libs/Common/Dom/Dom.php
@@ -133,6 +133,7 @@ class Dom extends DOMDocument
      */
     public function addChild(&$parent, $name, $content = '', $obrigatorio = false, $descricao = "", $force = false)
     {
+        $content = trim($content);
         if ($obrigatorio && $content === '' && !$force) {
             $this->erros[] = array(
                 "tag" => $name,
@@ -140,8 +141,7 @@ class Dom extends DOMDocument
                 "erro" => "Preenchimento Obrigatório!"
             );
         }
-        if ($obrigatorio || $content !== '') {
-            $content = trim($content);
+        if ($obrigatorio || $content !== '' || $force) {
             $content = htmlspecialchars($content, ENT_QUOTES);
             $temp = $this->createElement($name, $content);
             $parent->appendChild($temp);


### PR DESCRIPTION
para remover espaços em  branco do parâmetro "content" antes da avaliação e construção da TAG, para evitar a inserção de TAG por passagem incorreta de dados