### PR TITLE
Update MakeNFe.php

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -3613,13 +3613,15 @@ class MakeNFe extends BaseMake
                 false,
                 "Tipo de Integração para pagamento"
             );
-            $this->dom->addChild(
-                $card,
-                "CNPJ",
-                $cnpj,
-                true,
-                "CNPJ da Credenciadora de cartão de crédito e/ou débito"
-            );
+            if (!empty($cnpj)){
+                $this->dom->addChild(
+                    $card,
+                    "CNPJ",
+                    $cnpj,
+                    true,
+                    "CNPJ da Credenciadora de cartão de crédito e/ou débito"
+                );
+            }
             $this->dom->addChild(
                 $card,
                 "tBand",
@@ -3627,13 +3629,15 @@ class MakeNFe extends BaseMake
                 true,
                 "Bandeira da operadora de cartão de crédito e/ou débito"
             );
-            $this->dom->addChild(
-                $card,
-                "cAut",
-                $cAut,
-                true,
-                "Número de autorização da operação cartão de crédito e/ou débito"
-            );
+            if (!empty($cAut)){
+                $this->dom->addChild(
+                    $card,
+                    "cAut",
+                    $cAut,
+                    true,
+                    "Número de autorização da operação cartão de crédito e/ou débito"
+                );
+            }
             $this->dom->appChild($this->aPag[count($this->aPag)-1], $card, '');
             return $card;
         }


### PR DESCRIPTION
Quando o emissor for obrigado a ter integração com o TEF (tpIntegra = 1) e o tipo de pagamento for cartão de crédito (03) ou débito (04), os campos código de autorização e CNPJ da administradora precisam ser informados, caso contrário não são necessários.
Assim, foi adicionado validação para informar esses campos no XML somente quando preenchidos.
Fonte: NT2015_002 v1.41 pág 27.