### PR TITLE
Update MakeNFe.php

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -3617,7 +3617,7 @@ class MakeNFe extends BaseMake
                 $card,
                 "CNPJ",
                 $cnpj,
-                true,
+                false,
                 "CNPJ da Credenciadora de cartão de crédito e/ou débito"
             );
             $this->dom->addChild(
@@ -3631,7 +3631,7 @@ class MakeNFe extends BaseMake
                 $card,
                 "cAut",
                 $cAut,
-                true,
+                false,
                 "Número de autorização da operação cartão de crédito e/ou débito"
             );
             $this->dom->appChild($this->aPag[count($this->aPag)-1], $card, '');


### PR DESCRIPTION
Os campos cAut e CNPJ nas formas de pagamento não são obrigatórias, quando o cliente não tem o sistema integrado ao TEF, esses campos não são necessariamente informados.