### PR TITLE
Removendo dependência com Service Manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "ext-fileinfo": "*",
         "ext-iconv": "*",
         "ext-mbstring": "*",
-        "zendframework/zend-servicemanager": "^2.5",
         "zendframework/zend-mail": "^2.5",
         "soundasleep/html2text": "~0.2",
         "mpdf/mpdf": "6.0.0",


### PR DESCRIPTION
O service manager não é obrigatório para rodar o projeto e esta dependência atrapalha o uso da biblioteca com aplicações que utilizam ZF3 por exemplo. Issue #894 