### PR TITLE
Correção pagamento tpIntegra == 2

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -3604,7 +3604,7 @@ class MakeNFe extends BaseMake
         $tpIntegra = ''
     ) {
         //apenas para modelo 65
-        if ($this->mod == '65' && $tBand != '') {
+        if ($this->mod == '65' && ($tBand != '' || $tpIntegra == '2')) {
             $card = $this->dom->createElement("card");
             $this->dom->addChild(
                 $card,
@@ -3624,7 +3624,7 @@ class MakeNFe extends BaseMake
                 $card,
                 "tBand",
                 $tBand,
-                true,
+                false,
                 "Bandeira da operadora de cartão de crédito e/ou débito"
             );
             $this->dom->addChild(


### PR DESCRIPTION
No caso do tipo de integração for igual a 2 (tpIntegra == 2),  os campos "cAut", "tBand" e "CNPJ" não precisam ser informados.

tpIntegra == 2 significa que o pagamento não integra com o sistema.