### PR TITLE
Update MakeNFe.php - Gerar múltiplas tags med

### DIFF
--- a/libs/NFe/MakeNFe.php
+++ b/libs/NFe/MakeNFe.php
@@ -1795,7 +1795,7 @@ class MakeNFe extends BaseMake
         $this->dom->addChild($med, "dFab", $dFab, true, "$identificador [item $nItem] Data de fabricação");
         $this->dom->addChild($med, "dVal", $dVal, true, "$identificador [item $nItem] Data de validade");
         $this->dom->addChild($med, "vPMC", $vPMC, true, "$identificador [item $nItem] Preço máximo consumidor");
-        $this->aMed[$nItem] = $med;
+        $this->aMed[$nItem][] = $med;
         return $med;
     }
     
@@ -4096,9 +4096,11 @@ class MakeNFe extends BaseMake
         //insere medicamentos
         if (!empty($this->aMed)) {
             foreach ($this->aMed as $nItem => $child) {
-                $prod = $this->aProd[$nItem];
-                $this->dom->appChild($prod, $child, "Inclusão do node medicamento");
-                $this->aProd[$nItem] = $prod;
+				foreach($child as $grandChild){
+                	$prod = $this->aProd[$nItem];
+                	$this->dom->appChild($prod, $grandChild, "Inclusão do node medicamento");
+                	$this->aProd[$nItem] = $prod;
+				}
             }
         }
         //insere armas


### PR DESCRIPTION
Estas alterações permitem que sejam geradas múltiplas tags de medicamento para cada produto.
Trabalhando com medicamentos, percebeu-se a necessidade de gerar mais de uma tag para controle de lote do medicamento, porém a biblioteca implementava apenas uma tag <med> por produto.
Com as alterações implementadas, é criado um array ( que guarda várias tags) dentro de outro array (que guarda os medicamentos por número) usado para gravar múltiplas tags <med> com suas propriedades, quando houver lotes de medicamento. Pode ser usado chamando a função "nfe->tagmed()" em um laço de repetição ou quantas vezes forem necessárias.
Obrigado.