### PR TITLE
Verifica se a constante FPDF_VERSION existe antes de definir

### DIFF
--- a/libs/Extras/FPDF/fpdf.php
+++ b/libs/Extras/FPDF/fpdf.php
@@ -2,7 +2,9 @@
 
 namespace NFePHP\Extras\FPDF;
 
-define('FPDF_VERSION', '1.6');
+if (!defined('FPDF_VERSION')) {
+    define('FPDF_VERSION', '1.6');
+}
 
 class FPDF
 {


### PR DESCRIPTION
Existem outros repositórios que definem essa constante, se você tentar redefinir, vai lançar uma excessão.

Acredito que não teriam grandes efeitos colaterias negativos.