### PR TITLE
Update Danfe.php - Exibição de múltiplos lotes

### DIFF
--- a/libs/Extras/Danfe.php
+++ b/libs/Extras/Danfe.php
@@ -2338,7 +2338,7 @@ class Danfe extends CommonNFePHP implements DocumentoNFePHP
         if (isset($med)) {
             $i = 0;
             while ($i < $med->length) {
-                $medTxt .= $this->pSimpleGetValue($med->item($i), 'nLote', ' Lote: ');
+                $medTxt .= $this->pSimpleGetValue($med->item($i), 'nLote', '\n Lote: ');
                 $medTxt .= $this->pSimpleGetValue($med->item($i), 'qLote', ' Quant: ');
                 $medTxt .= $this->pSimpleGetDate($med->item($i), 'dFab', ' Fab: ');
                 $medTxt .= $this->pSimpleGetDate($med->item($i), 'dVal', ' Val: ');


### PR DESCRIPTION
Com esta pequena alteração, quando inseridos vários lotes de medicamentos por meio da tag <med>, as informações do lote na DANFE não ficarão todas na mesma linha, quebrando a linha por cada lote.