### PR TITLE
Correção da sigla do estado do Ceará.

### DIFF
--- a/exemplos/sql/estados.sql
+++ b/exemplos/sql/estados.sql
@@ -29,7 +29,7 @@ INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (
 INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (3, 'Amapá', 'AP', '16');
 INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (4, 'Amazonas', 'AM', '13');
 INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (5, 'Bahia', 'BA', '29');
-INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (6, 'Ceará', 'Ce', '23');
+INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (6, 'Ceará', 'CE', '23');
 INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (7, 'Distrito Federal', 'DF', '53');
 INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (8, 'Espírito Santo', 'ES', '32');
 INSERT INTO `estado` (id_estado, nome_estado, uf_estado, codigo_estado) VALUES (9, 'Goiás', 'GO', '52');


### PR DESCRIPTION
Alterado a sigla do estado do Ceará de 'Ce' para 'CE' na linha 32, seguindo assim o padrão de letras maiúsculas.